### PR TITLE
PARQUET-1674: The announcement email on the web site does not comply with ASF rules

### DIFF
--- a/output/contribute/index.html
+++ b/output/contribute/index.html
@@ -246,7 +246,7 @@ To enable run the following command and then open a browser and navigate to
 <h3 id="publishing-the-site">Publishing the Site</h3>
 
 <p>The website uses gitpubsub. The output folder contains the websites content
-and when committed to the git repository it will be automatically deployed to 
+and when committed to the git repository it will be automatically deployed to
 the live site. </p>
 
 	  </div>

--- a/output/documentation/how-to-release/index.html
+++ b/output/documentation/how-to-release/index.html
@@ -249,7 +249,12 @@ svn co https://dist.apache.org/repos/dist/release/parquet releases
 svn add apache-parquet-&lt;version&gt;
 svn ci -m "Parquet: Add release &lt;VERSION&gt;"
 </code></pre></div>
-<h4 id="3-send-an-announce-e-mail-to-announce-apache-org-and-the-dev-list">3. Send an ANNOUNCE e-mail to <a href="mailto:announce@apache.org">announce@apache.org</a> and the dev list</h4>
+<h4 id="3-update-parquet-apache-org">3. Update parquet.apache.org</h4>
+
+<p>Update the downloads page on parquet.apache.org.
+Instructions for updating the site are on the <a href="http://parquet.apache.org/contribute/">contribution page</a>.</p>
+
+<h4 id="4-send-an-announce-e-mail-to-announce-apache-org-and-the-dev-list">4. Send an ANNOUNCE e-mail to <a href="mailto:announce@apache.org">announce@apache.org</a> and the dev list</h4>
 <div class="highlight"><pre class="highlight plaintext"><code>[ANNOUNCE] Apache Parquet release &lt;VERSION&gt;
 </code></pre></div><div class="highlight"><pre class="highlight plaintext"><code>I'm please to announce the release of Parquet &lt;VERSION&gt;!
 
@@ -257,19 +262,14 @@ Parquet is a general-purpose columnar file format for nested data. It uses
 space-efficient encodings and a compressed and splittable structure for
 processing frameworks like Hadoop.
 
-Changes are listed at: &lt;CHANGES-URL&gt;
+Changes are listed at: https://github.com/apache/parquet-mr/blob/apache-parquet-&lt;VERSION&gt;/CHANGES.md
 
-This release can be downloaded from: https://www.apache.org/dyn/closer.cgi/parquet/&lt;TARBALL NAME WITHOUT .tar.gz&gt;/&lt;TARBALL NAME&gt;
+This release can be downloaded from: https://parquet.apache.org/downloads/
 
 Java artifacts are available from Maven Central.
 
 Thanks to everyone for contributing!
 </code></pre></div>
-<h4 id="4-update-parquet-apache-org">4. Update parquet.apache.org</h4>
-
-<p>Update the downloads page on parquet.apache.org.
-Instructions for updating the site are on the <a href="http://parquet.apache.org/contribute/">contribution page</a>.</p>
-
 <h3 id="what-to-do-if-a-vote-fails">What to do if a vote fails</h3>
 
 <p>If a vote fails, you need to remove the release tag that was created by the <code>dev/prepare-release.sh</code> script:</p>

--- a/output/downloads/index.html
+++ b/output/downloads/index.html
@@ -130,6 +130,8 @@
       <div class="container">
         <h1 id="downloads">Downloads</h1>
 
+<h2 id="parquet-format">Parquet Format</h2>
+
 <p>The <a href="https://www.apache.org/dyn/closer.lua/parquet/apache-parquet-format-2.7.0/apache-parquet-format-2.7.0.tar.gz">latest version of parquet-format is 2.7.0</a>.</p>
 
 <p>To <a href="https://www.apache.org/info/verification.html">check the validity</a> of this release, use its:</p>
@@ -138,6 +140,18 @@
 <li><a href="https://www.apache.org/dist/parquet/KEYS">Release manager OpenPGP key</a></li>
 <li><a href="https://www.apache.org/dist/parquet/apache-parquet-format-2.7.0/apache-parquet-format-2.7.0.tar.gz.asc">OpenPGP signature</a></li>
 <li><a href="https://www.apache.org/dist/parquet/apache-parquet-format-2.7.0/apache-parquet-format-2.7.0.tar.gz.sha512">SHA-512</a></li>
+</ul>
+
+<h2 id="parquet-mr">Parquet MR</h2>
+
+<p>The <a href="https://www.apache.org/dyn/closer.lua/parquet/apache-parquet-1.10.1/apache-parquet-1.10.1.tar.gz">latest version of parquet-mr is 1.10.1</a>.</p>
+
+<p>To <a href="https://www.apache.org/info/verification.html">check the validity</a> of this release, use its:</p>
+
+<ul>
+<li><a href="https://www.apache.org/dist/parquet/KEYS">Release manager OpenPGP key</a></li>
+<li><a href="https://www.apache.org/dist/parquet/apache-parquet-1.10.1/apache-parquet-1.10.1.tar.gz.asc">OpenPGP signature</a></li>
+<li><a href="https://www.apache.org/dist/parquet/apache-parquet-1.10.1/apache-parquet-1.10.1.tar.gz.sha512">SHA-512</a></li>
 </ul>
 
 <h3 id="downloading-from-the-maven-central-repository">Downloading from the Maven central repository</h3>

--- a/source/contribute.html.md
+++ b/source/contribute.html.md
@@ -120,6 +120,6 @@ To enable run the following command and then open a browser and navigate to
 
 ### Publishing the Site
 The website uses gitpubsub. The output folder contains the websites content
-and when committed to the git repository it will be automatically deployed to 
+and when committed to the git repository it will be automatically deployed to
 the live site. 
 

--- a/source/documentation/how-to-release.html.md
+++ b/source/documentation/how-to-release.html.md
@@ -151,8 +151,14 @@ svn add apache-parquet-<version>
 svn ci -m "Parquet: Add release <VERSION>"
 ```
 
+#### 3. Update parquet.apache.org
 
-#### 3. Send an ANNOUNCE e-mail to announce@apache.org and the dev list
+Update the downloads page on parquet.apache.org.
+Instructions for updating the site are on the [contribution page][parquet-site-docs].
+
+[parquet-site-docs]: http://parquet.apache.org/contribute/
+
+#### 4. Send an ANNOUNCE e-mail to announce@apache.org and the dev list
 
 ```
 [ANNOUNCE] Apache Parquet release <VERSION>
@@ -164,22 +170,14 @@ Parquet is a general-purpose columnar file format for nested data. It uses
 space-efficient encodings and a compressed and splittable structure for
 processing frameworks like Hadoop.
 
-Changes are listed at: <CHANGES-URL>
+Changes are listed at: https://github.com/apache/parquet-mr/blob/apache-parquet-<VERSION>/CHANGES.md
 
-This release can be downloaded from: https://www.apache.org/dyn/closer.cgi/parquet/<TARBALL NAME WITHOUT .tar.gz>/<TARBALL NAME>
+This release can be downloaded from: https://parquet.apache.org/downloads/
 
 Java artifacts are available from Maven Central.
 
 Thanks to everyone for contributing!
 ```
-
-#### 4. Update parquet.apache.org
-
-Update the downloads page on parquet.apache.org.
-Instructions for updating the site are on the [contribution page][parquet-site-docs].
-
-[parquet-site-docs]: http://parquet.apache.org/contribute/
-
 
 ### What to do if a vote fails
 

--- a/source/downloads.html.md
+++ b/source/downloads.html.md
@@ -1,5 +1,7 @@
 # Downloads
 
+## Parquet Format
+
 The [latest version of parquet-format is 2.7.0](https://www.apache.org/dyn/closer.lua/parquet/apache-parquet-format-2.7.0/apache-parquet-format-2.7.0.tar.gz).
 
 To [check the validity](https://www.apache.org/info/verification.html) of this release, use its:
@@ -7,6 +9,16 @@ To [check the validity](https://www.apache.org/info/verification.html) of this r
  * [Release manager OpenPGP key](https://www.apache.org/dist/parquet/KEYS)
  * [OpenPGP signature](https://www.apache.org/dist/parquet/apache-parquet-format-2.7.0/apache-parquet-format-2.7.0.tar.gz.asc)
  * [SHA-512](https://www.apache.org/dist/parquet/apache-parquet-format-2.7.0/apache-parquet-format-2.7.0.tar.gz.sha512)
+
+## Parquet MR
+
+The [latest version of parquet-mr is 1.10.1](https://www.apache.org/dyn/closer.lua/parquet/apache-parquet-1.10.1/apache-parquet-1.10.1.tar.gz).
+
+To [check the validity](https://www.apache.org/info/verification.html) of this release, use its:
+
+ * [Release manager OpenPGP key](https://www.apache.org/dist/parquet/KEYS)
+ * [OpenPGP signature](https://www.apache.org/dist/parquet/apache-parquet-1.10.1/apache-parquet-1.10.1.tar.gz.asc)
+ * [SHA-512](https://www.apache.org/dist/parquet/apache-parquet-1.10.1/apache-parquet-1.10.1.tar.gz.sha512)
 
 ### Downloading from the Maven central repository
 


### PR DESCRIPTION
Apache requires to have our own download page that contains links to the source tarball, the related ASC and SHA512 files, the KEYS file and instructions for verifying the downloaded file. These links shall not be included in the announcement email but the link of the download page only.