### PR TITLE
documentation/latest: fix typo, adjust formatting

### DIFF
--- a/source/documentation/latest.html.md
+++ b/source/documentation/latest.html.md
@@ -22,9 +22,9 @@ The [parquet-compatibility](https://github.com/Parquet/parquet-compatibility) pr
 
 ## Building
 
-Java resources can be build using `mvn package.` The current stable version should always be available from Maven Central.
+Java resources can be built using `mvn package`. The current stable version should always be available from Maven Central.
 
-C++ thrift resources can be generated via make.
+C++ thrift resources can be generated via `make`.
 
 Thrift can be also code-genned into any other thrift-supported language.
 


### PR DESCRIPTION
Small fixes to the content of this page: https://parquet.apache.org/documentation/latest/.