### PR TITLE
Add search functionality to the Parquet Website with Algolia 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -104,7 +104,7 @@ github_branch= "production"
 # gcs_engine_id = "7e3f91e3eadecceaa"
 
 # Enable Algolia DocSearch
-algolia_docsearch = false
+algolia_docsearch = true
 
 # Enable Lunr.js offline search
 offlineSearch = false

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,5 +1,0 @@
----
-title: Search Results
-layout: search
-
----

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,21 @@
+{{ with .Site.Params.algolia_docsearch }}
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+
+<script type="text/javascript">
+
+  docsearch({
+
+    appId: '399WOPSE6Q',
+
+    apiKey: '437a8e172549357b6ca768248caecff9',
+
+    indexName: 'parquet-apache',
+
+    container: '#search_box',
+
+    debug: true // Set debug to true if you want to inspect the modal
+
+  });
+
+</script>
+{{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,3 @@
+{{ with .Site.Params.algolia_docsearch }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"/></pre></li>
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,35 @@
+{{ $cover := and (.HasShortcode "blocks/cover") (not .Site.Params.ui.navbar_translucent_over_cover_disable) }}
+<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
+        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="font-weight-bold">{{ .Site.Title }}</span>
+	</a>
+	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
+		<ul class="navbar-nav mt-2 mt-lg-0">
+			{{ $p := . }}
+			{{ range .Site.Menus.main }}
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
+				{{ with .Page }}
+				{{ $active = or $active ( $.IsDescendant .)  }}
+				{{ end }}
+				{{ $pre := .Pre }}
+				{{ $post := .Post }}
+				{{ $url := urls.Parse .URL }}
+				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
+			</li>
+			{{ end }}
+			{{ if  .Site.Params.versions }}
+			<li class="nav-item dropdown mr-4 d-none d-lg-block">
+				{{ partial "navbar-version-selector.html" . }}
+			</li>
+			{{ end }}
+			{{ if  (gt (len .Site.Home.Translations) 0) }}
+			<li class="nav-item dropdown mr-4 d-none d-lg-block">
+				{{ partial "navbar-lang-selector.html" . }}
+			</li>
+			{{ end }}
+		</ul>
+	</div>
+	<div id="search_box" class="navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
+</nav>


### PR DESCRIPTION
Search functionality now exists across the website. See screenshots below as an example.

<img width="1664" alt="Screen Shot 2022-04-01 at 9 07 51 AM" src="https://user-images.githubusercontent.com/2461070/161269786-cff65783-597f-48c5-9476-ee701073170c.png">
<img width="1679" alt="Screen Shot 2022-04-01 at 9 08 02 AM" src="https://user-images.githubusercontent.com/2461070/161269792-a231f0a4-d753-4061-87ff-0363dd42ccf0.png">

