### PR TITLE
add InfluxDB blog post link about Parquet catalog

### DIFF
--- a/content/en/docs/Learning Resources/Blog Posts/_index.md
+++ b/content/en/docs/Learning Resources/Blog Posts/_index.md
@@ -9,3 +9,5 @@ description: >
 * [Apache Parquet: Cost Efficiency @ Scale in Big Data File Format](https://eng.uber.com/cost-efficiency-big-data/)
 
 * [One Stone, Three Birds: Finer-Grained Encryption @ Apache Parquet](https://eng.uber.com/one-stone-three-birds-finer-grained-encryption-apache-parquet/)
+
+* [Designing a Parquet Catalog for InfluxDB IOx](https://www.influxdata.com/blog/designing-a-parquet-catalog-for-influxdb-iox/)


### PR DESCRIPTION
adding a link to the blog posts resource section to a post about how InfluxDB is using Parquet for their new storage engine