### PR TITLE
Dropping go to 1.12 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/apache/parquet-site
 
-go 1.23
+go 1.12
 
 require github.com/google/docsy v0.9.1 // indirect


### PR DESCRIPTION
This should fix the build. There was an issue that has to do with missing toolchain here: https://github.com/golang/go/issues/62278 