### PR TITLE
Fix hugo deprecation warning

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,12 +48,12 @@ anchor = "smart"
 [languages]
 [languages.en]
 title = "Apache Parquet"
-description = "The Apache Parquet Website"
 languageName ="English"
 contentDir = "content/en"
 # Weight used for sorting.
 weight = 1
-
+[languages.en.params]
+description = "The Apache Parquet Website"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
This PR fixes a deprecation warning emitted by hugo:

```
WARN  deprecated: config: languages.en.description: custom params on the language top level
was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below
[languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```