### PR TITLE
Add Dockerfile + instructions on how to preview site using docker rather than installing `hugo` locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Dockerfile for running the Parquet website locally
+#
+# Build an image called parquet-site with necessary tools
+# docker build -t parquet-site .
+#
+# Run
+# run docker container mounting the current directory to /parquet-site and exposing port 1313
+# docker run -it -v `pwd`:/parquet-site -p 1313:1313  parquet-site
+#
+# Now you can run npm and hugo commands in the container
+FROM debian:bullseye-slim
+
+# run docker container mounting the current directory to /parquet-site and exposing port 1313
+
+# Install necessary utilities
+RUN apt-get update
+RUN apt-get install wget git -y xz-utils
+
+# Install extended version of hugo to /hugo
+# See releases https://github.com/gohugoio/hugo/releases/tag/v0.124.1
+# Note, if on amd64 use https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-amd64.tar.gz
+RUN wget -O - https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-arm64.tar.gz  | tar xz
+
+# install golang to /go
+RUN wget -O - https://go.dev/dl/go1.22.3.linux-amd64.tar.gz | tar xz
+
+# install nodejs to /node-v20.13.1-linux-arm64
+RUN wget -O - https://nodejs.org/dist/v20.13.1/node-v20.13.1-linux-arm64.tar.xz | xz -d | tar x
+
+# setup path to find binaries
+ENV PATH=.:/go/bin:/node-v20.13.1-linux-arm64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get install wget git -y xz-utils
 # See releases https://github.com/gohugoio/hugo/releases/tag/v0.124.1
 # Note, if on amd64 use https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-amd64.tar.gz
 RUN wget -O - https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-arm64.tar.gz  | tar xz
+RUN mv /hugo /usr/local/bin/hugo
 
 # install golang to /go
 RUN wget -O - https://go.dev/dl/go1.22.3.linux-amd64.tar.gz | tar xz
@@ -45,6 +46,6 @@ RUN wget -O - https://go.dev/dl/go1.22.3.linux-amd64.tar.gz | tar xz
 RUN wget -O - https://nodejs.org/dist/v20.13.1/node-v20.13.1-linux-arm64.tar.xz | xz -d | tar x
 
 # setup path to find binaries
-ENV PATH=.:/go/bin:/node-v20.13.1-linux-arm64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/go/bin:/node-v20.13.1-linux-arm64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This website is built / powered by [Hugo](https://gohugo.io/), and extended from the [Docsy Theme](https://www.docsy.dev/).
 
-The following steps assume that you have `hugo` installed and working.
+The following steps assume that you have `hugo` installed and working. 
+You can also use docker, see the [Docker section](#docker) for more information.
 
 ## Building and Running Locally
 
@@ -14,7 +15,7 @@ cd parquet-site
 git submodule update --init --recursive
 ```
 
-To build or update your site’s CSS resources, you also need PostCSS to create the final assets. By default npm installs tools under the directory where you run npm install.
+To build or update CSS resources, you also need PostCSS to create the final assets.  By default npm installs tools under the directory where you run npm install.
 
 ```
 npm install -D autoprefixer
@@ -22,13 +23,53 @@ npm install -D postcss-cli
 npm install -D postcss
 ```
 
-To run this website site locally, run the following in the root of the directory:
+To preview this website site locally, run the following in the root of the directory:
 
 ```shell
 hugo server
 ```
 
-# Release Documentation
+## Building and Running in Docker
+
+If you don't want to install `hugo` and its dependencies local machine, you can use
+docker to preview locally.  First checkout the `parquet-site` explained above 
+and then run:
+
+```shell
+# run docker container mounting the current directory to /parquet-site and exposing port 1313
+docker run -it -v `pwd`:/parquet-site -p 1313:1313  debian:bullseye-slim  bash
+
+# Install necessary utilities
+apt-get update
+apt-get install wget git -y xz-utils
+
+# Install extended version of hugo to /hugo
+# See releases https://github.com/gohugoio/hugo/releases/tag/v0.124.1
+# Note, if on amd64 use https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-amd64.tar.gz
+wget -O - https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-arm64.tar.gz  | tar xz
+
+# install golang to /go
+wget -O - https://go.dev/dl/go1.22.3.linux-amd64.tar.gz | tar xz
+
+# install nodejs to /node-v20.13.1-linux-arm64
+wget -O - https://nodejs.org/dist/v20.13.1/node-v20.13.1-linux-arm64.tar.xz | xz -d | tar x
+
+# setup path to find binaries
+export PATH=/:/go/bin:/node-v20.13.1-linux-arm64/bin:$PATH
+
+# Install necessary npm modules in parquet-site directory
+cd parquet-site
+npm install -D autoprefixer
+npm install -D postcss-cli
+npm install -D postcss
+
+# Run server
+hugo server --bind 0.0.0.0
+```
+
+You can now preview the site locally on http://localhost:1313/
+
+# Release Process
 
 To create documentation for a new release of `parquet-format` create a new <releaseNumber>.md file under `content/en/blog/parquet-format`. Please see existing files in that directory as an example.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ hugo server
 
 ## Building and Running in Docker
 
-If you don't want to install `hugo` and its dependencies local machine, you can use
+If you don't want to install `hugo` and its dependencies on local machine, you can use
 docker to preview locally.  First checkout the `parquet-site` explained above 
 and then run:
 

--- a/README.md
+++ b/README.md
@@ -31,32 +31,24 @@ hugo server
 
 ## Building and Running in Docker
 
-If you don't want to install `hugo` and its dependencies on local machine, you can use
-docker to preview locally.  First checkout the `parquet-site` explained above 
-and then run:
+If you don't want to install `hugo` and its dependencies on your local machine,
+you can use docker as well. To do so, checkout the `parquet-site` explained
+above and then build an image from [Dockerfile](Dockerfile) with the required
+tools:
 
 ```shell
-# run docker container mounting the current directory to /parquet-site and exposing port 1313
-docker run -it -v `pwd`:/parquet-site -p 1313:1313  debian:bullseye-slim  bash
+docker build -t parquet-site .
+````
 
-# Install necessary utilities
-apt-get update
-apt-get install wget git -y xz-utils
+Then run the container mounting the current directory to `/parquet-site` and
+exposing local port 1313:
 
-# Install extended version of hugo to /hugo
-# See releases https://github.com/gohugoio/hugo/releases/tag/v0.124.1
-# Note, if on amd64 use https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-amd64.tar.gz
-wget -O - https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-arm64.tar.gz  | tar xz
+```shell
+docker run -it -v `pwd`:/parquet-site -p 1313:1313  parquet-site
+```
 
-# install golang to /go
-wget -O - https://go.dev/dl/go1.22.3.linux-amd64.tar.gz | tar xz
-
-# install nodejs to /node-v20.13.1-linux-arm64
-wget -O - https://nodejs.org/dist/v20.13.1/node-v20.13.1-linux-arm64.tar.xz | xz -d | tar x
-
-# setup path to find binaries
-export PATH=/:/go/bin:/node-v20.13.1-linux-arm64/bin:$PATH
-
+Once inside the container, you can run the following to preview the site:
+```shell
 # Install necessary npm modules in parquet-site directory
 cd parquet-site
 npm install -D autoprefixer

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ hugo server
 ## Building and Running in Docker
 
 If you don't want to install `hugo` and its dependencies on your local machine,
-you can use docker as well. To do so, checkout the `parquet-site` explained
-above and then build an image from [Dockerfile](Dockerfile) with the required
+you can use docker. To do so, checkout the `parquet-site` repo as explained
+above and then use [Dockerfile](Dockerfile) to build an image with the required
 tools:
 
 ```shell
@@ -47,16 +47,14 @@ exposing local port 1313:
 docker run -it -v `pwd`:/parquet-site -p 1313:1313  parquet-site
 ```
 
-Once inside the container, you can run the following to preview the site:
+Once inside the container, run the following to preview the site:
 ```shell
 # Install necessary npm modules in parquet-site directory
 cd parquet-site
 npm install -D autoprefixer
 npm install -D postcss-cli
 npm install -D postcss
-
-# Run server
-hugo server --bind 0.0.0.0
+hugo server --bind 0.0.0.0 # run the server
 ```
 
 You can now preview the site locally on http://localhost:1313/

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/apache/parquet-site#readme",
   "devDependencies": {
-    "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.35",
     "postcss-cli": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/apache/parquet-site#readme",
   "devDependencies": {
-    "autoprefixer": "^10.4.18",
-    "postcss": "^8.4.35",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
     "postcss-cli": "^9.1.0"
   }
 }


### PR DESCRIPTION
In order to make changes to the website and have confidence that we won't break things we should make sure we can see the results of the work locally. 

I can't / don't want to try and figure out how to get a local `hugo` install running locally, and prefer to use docker.

I figured these instructions might help others

BTW I am happy to make a JIRA for this PR, but it isn't clear to me if that is desired or not in Parquet