### PR TITLE
Update README.md on asf-site branch with pointer to real readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,5 @@
-# Website development and deployment
+Source code for https://parquet.apache.org/
 
-## Staging
-To make a change to the `staging` version of the website:
-1. Make a PR against the `staging` branch in the repository
-2. Once the PR is merged, the `Build and Deploy Parquet Site`
-job in the [deployment workflow](./.github/workflows/deploy.yml) will be run, populating the `asf-staging` branch on this repo with the necessary files.
+The files on this `asf-site` branch should not be modified directly. See the instructions on [the `production` branch].
 
-**Do not directly edit the `asf-staging` branch of this repo**
-
-## Production
-
-To make a change to the `production` version of the website:
-1. Make a PR against the `production` branch in the repository
-2. Once the PR is merged, the `Build and Deploy Parquet Site`
-job in the [deployment workflow](./.github/workflows/deploy.yml) will be run, populating the `asf-site` branch on this repo with the necessary files.
-
-**Do not directly edit the `asf-site` branch of this repo**
+[the `production` branch]: https://github.com/apache/parquet-site/tree/production


### PR DESCRIPTION
Note that this PR purposely targets the `asf-site` branch rather than the `development` or `production` branches

## Rationale
The landing page of https://github.com/apache/parquet-site is confusing (it seems to have an outdated readme):

![Screenshot 2024-05-11 at 2 40 24 PM](https://github.com/apache/parquet-site/assets/490673/bf9c3187-e69a-4423-aaca-84a78b393e61)

It was not immediately clear to me that `asf-site` branch is hosts the output of statically building the website and that the updated README / etc are on the `production` branch

## Changes
Update the README to direct people to the `production` branch which has an updated readme
