### PR TITLE
Remove staging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,8 +18,5 @@ github:
   collaborators:  # Note: the number of collaborators is limited to 10
     - vinooganesh
 
-staging:
-  profile: ~
-  whoami:  asf-staging 
 publish:
   whoami:  asf-site


### PR DESCRIPTION
There still needs to be an infra ticket filed to actually delete the `staging` branch (unless a PMC member can delete the branch)