### PR TITLE
PARQUET-2470: Update website with larger ecosystem emphasis

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -9,7 +9,10 @@ title: Parquet
 <a class="btn btn-lg btn-secondary me-3 mb-4" href="/blog/">
   Download <i class="fab fa-github ms-2 "></i>
 </a>
-<p class="lead mt-5">Apache Parquet is a columnar storage format available to any project in the Hadoop ecosystem, regardless of the choice of data processing framework, data model or programming language.</p>
+<p class="lead mt-5">
+Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. 
+It provides high performance data compression and encoding schemes with to handle complex data in bulk.
+</p>
 {{< blocks/link-down color="info" >}}
 {{< /blocks/cover >}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -11,7 +11,7 @@ title: Parquet
 </a>
 <p class="lead mt-5">
 Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. 
-It provides high performance data compression and encoding schemes to handle complex data in bulk.
+It provides high performance compression and encoding schemes to handle complex data in bulk and is supported in many programming language and analytics tools.
 </p>
 {{< blocks/link-down color="info" >}}
 {{< /blocks/cover >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -11,7 +11,7 @@ title: Parquet
 </a>
 <p class="lead mt-5">
 Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. 
-It provides high performance data compression and encoding schemes with to handle complex data in bulk.
+It provides high performance data compression and encoding schemes to handle complex data in bulk.
 </p>
 {{< blocks/link-down color="info" >}}
 {{< /blocks/cover >}}

--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -44,4 +44,3 @@ Here is a non-exhaustive list of Parquet implementations:
 * [Apache Impala](https://github.com/apache/impala)
 * [DuckDB](https://github.com/duckdb/duckdb)
 * [fastparquet, a Python implementation of the Apache Parquet format](https://github.com/dask/fastparquet)
->>>>>>> origin/production

--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -6,7 +6,6 @@ description: >
   All about Parquet.
 ---
 
-Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. 
-It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk.
-Parquet is available in multiple languages including Java, C++, and Python.
+Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval.
+It provides high performance compression and encoding schemes to handle complex data in bulk and is supported in many programming language and analytics tools.
 

--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -6,4 +6,7 @@ description: >
   All about Parquet.
 ---
 
-Apache Parquet is a columnar storage format available to any project in the Hadoop ecosystem, regardless of the choice of data processing framework, data model or programming language.
+Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. 
+It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk.
+Parquet is available in multiple languages including Java, C++, and Python.
+

--- a/static/doap_Parquet.rdf
+++ b/static/doap_Parquet.rdf
@@ -28,7 +28,7 @@
     <homepage rdf:resource="http://parquet.apache.org" />
     <asfext:pmc rdf:resource="http://parquet.apache.org" />
     <shortdesc>Apache Parquet is a general-purpose columnar storage format.</shortdesc>
-    <description>Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Parquet is available in multiple languages including Java, C++, and Python.</description>
+    <description>Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. It provides high performance compression and encoding schemes to handle complex data in bulk and is supported in many programming language and analytics tools.</description>
     <bug-database rdf:resource="https://issues.apache.org/jira/browse/PARQUET" />
     <mailing-list rdf:resource="https://parquet.apache.org/community/" />
     <download-page rdf:resource="https://parquet.apache.org/blog/2023/05/18/1.13.1/" />


### PR DESCRIPTION
# Rationale
As described on https://issues.apache.org/jira/browse/PARQUET-2470, Parquet's role in the analytics ecosystem is substantial. 

However, https://parquet.apache.org/ currently emphasis Parquet's role in the Hadoop ecosystem. I think this causes confusion in several ways:

1. It implies that parquet is only focused on Hadoop, when I think it is a critical technology across other ecosystems that are unrelated to hadoop (e.g. Apache Iceberg, Delta Lake, etc)
2. It may further the perception that the Apache Parquet project only focuses on / cares about Hadoop / Java implementation

# Changes
Update the home page content to mirror the Apache Project Description https://projects.apache.org/project.html?parquet (which does not mention Hadoop specifically)

> Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Parquet is available in multiple languages including Java, C++, and Python.



## Before this PR

![Screenshot 2024-05-13 at 4 13 31 PM](https://github.com/apache/parquet-site/assets/490673/86a76878-f304-4d43-8156-a3555ccebfbc)


## After the PR

![Screenshot 2024-05-13 at 4 15 17 PM](https://github.com/apache/parquet-site/assets/490673/7479dd8f-3054-410e-9c14-4a8d2a0dccaa)
