### PR TITLE
Updating refereces from parquet-mr -> parquet-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can now preview the site locally on http://localhost:1313/
 
 To create documentation for a new release of `parquet-format` create a new <releaseNumber>.md file under `content/en/blog/parquet-format`. Please see existing files in that directory as an example.
 
-To create documentation for a new release of `parquet-mr` create a new <releaseNumber>.md file under `content/en/blog/parquet-mr`. Please see existing files in that directory as an example.
+To create documentation for a new release of `parquet-java` create a new <releaseNumber>.md file under `content/en/blog/parquet-java`. Please see existing files in that directory as an example.
 
 # Website development and deployment
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -24,8 +24,8 @@ Or Search Open Issues
 {{% /blocks/feature %}}
 
 
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/apache/parquet-mr" %}}
-We do a [Pull Request](https://github.com/apache/parquet-mr/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/apache/parquet-java" %}}
+We do a [Pull Request](https://github.com/apache/parquet-java/pulls) contributions workflow on **GitHub**. New users are always welcome!
 {{% /blocks/feature %}}
 
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -22,8 +22,8 @@ It provides high performance compression and encoding schemes to handle complex 
 Or Search Open Issues
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/apache/parquet-mr" %}}
-We do a [Pull Request](https://github.com/apache/parquet-mr/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/apache/parquet-java" %}}
+We do a [Pull Request](https://github.com/apache/parquet-java/pulls) contributions workflow on **GitHub**. New users are always welcome!
 {{% /blocks/feature %}}
 
 

--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -18,9 +18,9 @@ The parquet-format repository hosts the official specification of the Apache Par
 As a repository focused on specification, the parquet-format repository does not contain source code. 
 
 
-### parquet-java
+### parquet-java 
 
-The parquet-java repository is part of the Apache Parquet project and specifically focuses on providing Java tools for handling the Parquet file format. Essentially, this repository includes all the necessary Java libraries and modules that allow developers to read and write Apache Parquet files.
+The parquet-java (formerly named 'parquet-mr') repository is part of the Apache Parquet project and specifically focuses on providing Java tools for handling the Parquet file format. Essentially, this repository includes all the necessary Java libraries and modules that allow developers to read and write Apache Parquet files.
 
 The parquet-java repository contains an implementation of the Apache Parquet format. There are a number of other Parquet format implementations, which are listed below. 
 

--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -9,7 +9,7 @@ description: >
 Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval.
 It provides high performance compression and encoding schemes to handle complex data in bulk and is supported in many programming language and analytics tools.
 
-This documentation contains information about both the [parquet-mr](https://github.com/apache/parquet-mr) and [parquet-format](https://github.com/apache/parquet-format) repositories. 
+This documentation contains information about both the [parquet-java](https://github.com/apache/parquet-java) and [parquet-format](https://github.com/apache/parquet-format) repositories. 
 
 ### parquet-format
 
@@ -18,14 +18,14 @@ The parquet-format repository hosts the official specification of the Apache Par
 As a repository focused on specification, the parquet-format repository does not contain source code. 
 
 
-### parquet-mr
+### parquet-java
 
-The parquet-mr repository is part of the Apache Parquet project and specifically focuses on providing Java tools for handling the Parquet file format within the Hadoop ecosystem. The "mr" stands for MapReduce. Essentially, this repository includes all the necessary Java libraries and modules that allow developers to read and write Apache Parquet files.
+The parquet-java repository is part of the Apache Parquet project and specifically focuses on providing Java tools for handling the Parquet file format. Essentially, this repository includes all the necessary Java libraries and modules that allow developers to read and write Apache Parquet files.
 
-The parquet-mr repository contains an implementation of the Apache Parquet format. There are a number of other Parquet format implementations, which are listed below. 
+The parquet-java repository contains an implementation of the Apache Parquet format. There are a number of other Parquet format implementations, which are listed below. 
 
-Included in parquet-mr:
-* Java Implementation: It contains the core Java implementation of the Apache Parquet format, making it possible to use Parquet files in Java applications, particularly those based on Hadoop.
+Included in parquet-java:
+* Java Implementation: It contains the core Java implementation of the Apache Parquet format, making it possible to use Parquet files in Java applications.
 
 * Utilities and APIs: It provides various utilities and APIs for working with Apache Parquet files, including tools for data import/export, schema management, and data conversion.
 
@@ -36,7 +36,7 @@ The Parquet ecosystem is rich and varied, encompassing a wide array of tools, li
 
 Here is a non-exhaustive list of Parquet implementations:
 
-* [Parquet-mr](https://github.com/apache/parquet-mr)
+* [Parquet-java](https://github.com/apache/parquet-java)
 * [Parquet C++, a subproject of Arrow C++](https://github.com/apache/arrow/tree/main/cpp/src/parquet) ([documentation](https://arrow.apache.org/docs/cpp/parquet.html))
 * [Parquet Go, a subproject for Arrow Go](https://github.com/apache/arrow/tree/main/go/parquet) ([documentation](https://github.com/apache/arrow/tree/main/go))
 * [Parquet Rust](https://github.com/apache/arrow-rs/blob/master/parquet/README.md)

--- a/hugo.toml
+++ b/hugo.toml
@@ -20,7 +20,7 @@ enableGitInfo = true
 [[menu.main]]
     name = "GitHub"
     weight = 50
-    url = "https://github.com/apache/parquet-mr/"
+    url = "https://github.com/apache/parquet-java/"
     pre = "<i class='fab fa-github'></i>"
 
 # Configure how URLs look like per section.
@@ -163,7 +163,7 @@ enable = false
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
   name = "GitHub"
-  url = "https://github.com/apache/parquet-mr"
+  url = "https://github.com/apache/parquet-java"
   icon = "fab fa-github"
   desc = "Development takes place here!"
 [[params.links.developer]]

--- a/static/doap_Parquet.rdf
+++ b/static/doap_Parquet.rdf
@@ -43,8 +43,8 @@
     </release>
     <repository>
       <GitRepository>
-        <location rdf:resource="https://git.apache.org/repos/asf?p=parquet-mr.git"/>
-        <browse rdf:resource="https://github.com/apache/parquet-mr"/>
+        <location rdf:resource="https://git.apache.org/repos/asf?p=parquet-java.git"/>
+        <browse rdf:resource="https://github.com/apache/parquet-java"/>
       </GitRepository>
     </repository>
   </Project>


### PR DESCRIPTION
@alamb @wgtmac I put a very basic PR together to update *some* of the references on the website from `parquet-mr` to `parquet-java`. I only chose to do some because I think we have a few questions to figure out first:

1. Are we going to change the published artifact name of `parquet-mr` to `parquet-java` or do we just want to keep publishing under mr?
2. Do we want to actually "rewrite history" and update the past references (contributions, etc..) in the docs to refer to `parquet-java` instead? I'm not a fan of rewriting history but figured I'd start a conversation just in case people want to.
3. Should we also do a sweep and update the contribution guidelines / release template?  Per this thread https://lists.apache.org/thread/5oohcx3m16kqs8dmtl3vm1cgd8z0q10b.
4. Should we introduce a new section of the blog called `parquet-java` (I had been hacking using the blog for releases) to add a note (assuming we change the name of the artifact) that things have changed? 