### PR TITLE
GH-70: Add hyperlinks for mailing list subscription and archives

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -146,10 +146,20 @@ enable = false
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-  name = "User mailing list"
+  name = "Post to Mailing List"
   url = "mailto:dev@parquet.apache.org"
   icon = "fa fa-envelope"
-  desc = "Discussion and help from your fellow users. To subscribe please email dev-subscribe@parquet.apache.org. View the archive here: https://lists.apache.org/list.html?dev@parquet.apache.org."
+  desc = "Discussion and help from your fellow users"
+[[params.links.user]]
+  name = "Subscribe to Mailing List"
+  url = "mailto:dev-subscribe@parquet.apache.org"
+  icon = "fa fa-envelope-circle-check"
+  desc = "Subscribe to the mailing list to participate."
+[[params.links.user]]
+  name = "View Mailing List Archives"
+  url = "https://lists.apache.org/list.html?dev@parquet.apache.org"
+  icon = "fa fa-box-archive"
+  desc = "View archives of past discussions."
 [[params.links.user]]
   name ="Twitter"
   url = "https://twitter.com/ApacheParquet"


### PR DESCRIPTION
Closes https://github.com/apache/parquet-site/issues/70

Before this change the rls are not actually links. This put up a (minor) barrier to participating in the parquet communtity

![image](https://github.com/user-attachments/assets/837050f0-c5dd-4866-ad11-b65629d9d4a5)

After this change they are:

<img width="1410" alt="Screenshot 2024-07-17 at 5 20 53 AM" src="https://github.com/user-attachments/assets/2374edb4-6665-4cd0-ac2f-ace8c7c6e68b">
