### PR TITLE
GH-73: Rename `modules` page to `sub-projects`

### DIFF
--- a/content/en/docs/Contribution Guidelines/sub-projects.md
+++ b/content/en/docs/Contribution Guidelines/sub-projects.md
@@ -1,6 +1,6 @@
 ---
-title: "Modules"
-linkTitle: "Modules"
+title: "Sub-Projects"
+linkTitle: "Sub-Projects"
 weight: 1
 description: >
 


### PR DESCRIPTION
Closes #73

The "modules" page on the website https://parquet.apache.org/docs/contribution-guidelines/modules/ lists sub projects (aka links to other repositories)

<img width="908" alt="Screenshot 2024-07-17 at 5 25 57 AM" src="https://github.com/user-attachments/assets/7ec07bae-6b37-4fc8-8ae7-d42c141a2952">

I propose to make the content easier to find my renaming the section. Here is what the page looks like with this PR

<img width="1173" alt="Screenshot 2024-07-17 at 5 32 54 AM" src="https://github.com/user-attachments/assets/8449c31c-5354-4b2d-be73-ba02bc52d89c">
