### PR TITLE
MINOR: Skip tests when uploading JARs

### DIFF
--- a/content/en/docs/Contribution Guidelines/releasing.md
+++ b/content/en/docs/Contribution Guidelines/releasing.md
@@ -51,7 +51,7 @@ find ./ -type f -name 'pom.xml' -exec git checkout {} \;
 Upload binary artifacts for the release tag to [Nexus](https://repository.apache.org/):
 
 ```sh
-mvn release:perform
+mvn release:perform -DskipTests -Darguments=-DskipTests
 ```
 
 #### 3\. In Nexus, close the staging repository


### PR DESCRIPTION
Running the tests locally takes quite a bit of time.