### PR TITLE
Remove trailing backtick

### DIFF
--- a/content/en/blog/parquet-java/1.14.4.md
+++ b/content/en/blog/parquet-java/1.14.4.md
@@ -1,6 +1,6 @@
 ---
 title: "1.14.4"
-date: 2024-11-11`
+date: 2024-11-11
 description: >
 ---
 

--- a/content/en/blog/parquet-java/1.15.0.md
+++ b/content/en/blog/parquet-java/1.15.0.md
@@ -1,6 +1,6 @@
 ---
 title: "1.15.0"
-date: 2024-12-02`
+date: 2024-12-02
 description: >
 ---
 


### PR DESCRIPTION
This messes up the ordering:

<img width="755" alt="image" src="https://github.com/user-attachments/assets/c18afeef-a4a6-4e0f-85d7-076ad882ef11">
