### PR TITLE
Run CI on PRs and fail on warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Build and Deploy Parquet Site
 on:
   push:
     branches: [ production ]
+  pull_request:
 
 jobs:
   Build_and_Deploy_Site:
@@ -36,10 +37,11 @@ jobs:
       - run: npm install
 
       - name: Build
-        run: hugo --minify
+        run: hugo --minify --panicOnWarning
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/production'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: public

--- a/hugo.toml
+++ b/hugo.toml
@@ -102,9 +102,6 @@ github_branch= "production"
 # Comment out to disable search.
 # gcs_engine_id = "7e3f91e3eadecceaa"
 
-# Enable Algolia DocSearch
-algolia_docsearch = true
-
 # Enable Lunr.js offline search
 offlineSearch = false
 
@@ -112,6 +109,11 @@ offlineSearch = false
 prism_syntax_highlighting = false
 
 # User interface configuration
+
+[params.search.algolia]
+appId = '399WOPSE6Q'
+apiKey = '437a8e172549357b6ca768248caecff9'
+indexName = 'parquet-apache'
 
 [params.ui]
 #  Set to true to disable breadcrumb navigation.

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -2,20 +2,9 @@
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 
 <script type="text/javascript">
-
   docsearch({
-
-    appId: '399WOPSE6Q',
-
-    apiKey: '437a8e172549357b6ca768248caecff9',
-
-    indexName: 'parquet-apache',
-
     container: '#search_box',
-
-    debug: true // Set debug to true if you want to inspect the modal
-
+    debug: false // Set debug to true if you want to inspect the modal
   });
-
 </script>
 {{ end }}


### PR DESCRIPTION
The `angolia` search configuration was deprecated, so I took it from the docs:  https://www.docsy.dev/docs/adding-content/search/#algolia-docsearch

```
tml:4:7": execute of template failed: template: 404.html:4:7: executing "404.html" at <partial "head.html" .>: error calling partial: execute of template failed: template: partials/head.html:66:3: executing "algolia/head" at <warnf `Config 'params.algolia_docsearch' is deprecated: use 'params.search.algolia'
      For details, see https://www.docsy.dev/docs/adding-content/search/#algolia-docsearch.`>: error calling warnf: Config 'params.algolia_docsearch' is deprecated: use 'params.search.algolia'
      For details, see https://www.docsy.dev/docs/adding-content/search/#algolia-docsearch.
```