### PR TITLE
Add Go Parquet library to sub-projects

### DIFF
--- a/content/en/docs/Contribution Guidelines/sub-projects.md
+++ b/content/en/docs/Contribution Guidelines/sub-projects.md
@@ -14,4 +14,6 @@ The [parquet-cpp](https://arrow.apache.org/docs/cpp/parquet.html) project is a C
 
 The [parquet-rs](https://github.com/apache/arrow-rs/tree/master/parquet) project is a Rust library to read-write Parquet files.
 
+The [parquet-go](https://github.com/apache/arrow-go/tree/master/parquet) project is a Golang library to read-write Parquet files. It is part of the [Apache Arrow](https://arrow.apache.org/) Go implementation.
+
 The [parquet-compatibility](https://github.com/Parquet/parquet-compatibility) project (deprecated) contains compatibility tests that can be used to verify that implementations in different languages can read and write each other’s files. As of January 2022 compatibility tests only exist up to version 1.2.0.


### PR DESCRIPTION
Adding a link to the Go Parquet implementation within http://github.com/apache/arrow-go to the Sub-projects page for better discoverability. Like parquet-cpp being part of Arrow C++, the Go Parquet library is part of the Arrow implementation for Go.