### PR TITLE
Add DuckDB to Parquet implementations

### DIFF
--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -23,107 +23,107 @@ Implementations:
 * `Rust`: [parquet-rs](https://github.com/apache/arrow-rs/blob/main/parquet/README.md)
 * `cuDF`: [cudf](https://github.com/rapidsai/cudf)
 * `JavaScript`: [hyparquet](https://github.com/hyparam/hyparquet)
-
+* `DuckDB`: [duckdb](https://github.com/duckdb/duckdb)
 
 ### Physical types
 
-| Data type                                 | C++   | Java  | Go    | Rust  | cuDF  | hyparquet |
-| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- |
-| BOOLEAN                                   |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| INT32                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| INT64                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| INT96 (1)                                 |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| FLOAT                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DOUBLE                                    |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| BYTE_ARRAY                                |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| FIXED_LEN_BYTE_ARRAY                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
+| Data type                                 | C++   | Java  | Go    | Rust  | cuDF  | hyparquet | DuckDB |
+| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- | ------ |
+| BOOLEAN                                   |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
+| INT32                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
+| INT64                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
+| INT96 (1)                                 |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  (R)  |
+| FLOAT                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
+| DOUBLE                                    |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
+| BYTE_ARRAY                                |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
+| FIXED_LEN_BYTE_ARRAY                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  ✅   |
 
 * \(1) This type is deprecated, but as of 2024 it's common in currently produced parquet files
 
 
 ### Logical types
 
-| Data type                                 | C++   | Java  | Go    | Rust  | cuDF  | hyparquet |
-| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- |
-| STRING                                    |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| ENUM                                      |  ❌   |  ✅   |       |  ✅(1)|  ❌   | (R)       |
-| UUID                                      |  ❌   |  ✅   |       |  ✅(1)|  ❌   | (R)       |
-| 8, 16, 32, 64 bit signed and unsigned INT |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DECIMAL (INT32)                           |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DECIMAL (INT64)                           |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DECIMAL (BYTE_ARRAY)                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DECIMAL (FIXED_LEN_BYTE_ARRAY)            |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DATE                                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| TIME (INT32)                              |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| TIME (INT64)                              |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| TIMESTAMP (INT64)                         |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| INTERVAL                                  |  ✅   |  ✅(1)|       |  ✅   |  ❌   | (R)       |
-| JSON                                      |  ✅   |  ✅(1)|       |  ✅(1)|  ❌   | (R)       |
-| BSON                                      |  ❌   |  ✅(1)|       |  ✅(1)|  ❌   | (R)       |
-| LIST                                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| MAP                                       |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| UNKNOWN (always null)                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| FLOAT16                                   |  ✅   |  ✅(1)|       |  ✅   |  ✅   | (R)       |
+| Data type                                 | C++   | Java  | Go    | Rust  | cuDF  | hyparquet | DuckDB |
+| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- | ------ |
+| STRING                                    |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| ENUM                                      |  ❌   |  ✅   |       |  ✅(1)|  ❌   | (R)       |   ✅   |
+| UUID                                      |  ❌   |  ✅   |       |  ✅(1)|  ❌   | (R)       |   ✅   |
+| 8, 16, 32, 64 bit signed and unsigned INT |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| DECIMAL (INT32)                           |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| DECIMAL (INT64)                           |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| DECIMAL (BYTE_ARRAY)                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   (R)  |
+| DECIMAL (FIXED_LEN_BYTE_ARRAY)            |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| DATE                                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| TIME (INT32)                              |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| TIME (INT64)                              |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| TIMESTAMP (INT64)                         |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| INTERVAL                                  |  ✅   |  ✅(1)|       |  ✅   |  ❌   | (R)       |   ✅   |
+| JSON                                      |  ✅   |  ✅(1)|       |  ✅(1)|  ❌   | (R)       |   ✅   |
+| BSON                                      |  ❌   |  ✅(1)|       |  ✅(1)|  ❌   | (R)       |   ❌   |
+| LIST                                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| MAP                                       |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| UNKNOWN (always null)                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅  |
+| FLOAT16                                   |  ✅   |  ✅(1)|       |  ✅   |  ✅   | (R)       |   ✅   |
 
 * \(1) Only supported to use its annotated physical type
 
 ### Encodings
 
-| Encoding                                  | C++   | Java  | Go    | Rust  | cuDF  | hyparquet |
-| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- |
-| PLAIN                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| PLAIN_DICTIONARY                          |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| RLE_DICTIONARY                            |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| RLE                                       |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| BIT_PACKED (deprecated)                   |  ✅   |  ✅   |       |  ❌(1)|  (R)  | (R)       |
-| DELTA_BINARY_PACKED                       |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DELTA_LENGTH_BYTE_ARRAY                   |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| DELTA_BYTE_ARRAY                          |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| BYTE_STREAM_SPLIT                         |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
+| Encoding                                  | C++   | Java  | Go    | Rust  | cuDF  | hyparquet | DuckDB |
+| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- | ------ |
+| PLAIN                                     |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| PLAIN_DICTIONARY                          |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |  (R)   |
+| RLE_DICTIONARY                            |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| RLE                                       |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| BIT_PACKED (deprecated)                   |  ✅   |  ✅   |       |  ❌(1)|  (R)  | (R)       |   ❌   |
+| DELTA_BINARY_PACKED                       |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| DELTA_LENGTH_BYTE_ARRAY                   |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| DELTA_BYTE_ARRAY                          |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| BYTE_STREAM_SPLIT                         |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
 
 * \(1) Partial read support, but only in the case of level data with a bitwidth of 0
 
 ### Compressions
 
-| Compression                               | C++   | Java  | Go    | Rust  | cuDF  | hyparquet |
-| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- |
-| UNCOMPRESSED                              |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| BROTLI                                    |  ✅   |  ✅   |       |  ✅   |  (R)  | (R)       |
-| GZIP                                      |  ✅   |  ✅   |       |  ✅   |  (R)  | (R)       |
-| LZ4 (deprecated)                          |  ✅   |  ❌   |       |  ✅   |  ❌   | (R)       |
-| LZ4_RAW                                   |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| LZO                                       |  ❌   |  ❌   |       |  ❌   |  ❌   | ❌        |
-| SNAPPY                                    |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| ZSTD                                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
+| Compression                               | C++   | Java  | Go    | Rust  | cuDF  | hyparquet | DuckDB |
+| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- | ------ |
+| UNCOMPRESSED                              |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| BROTLI                                    |  ✅   |  ✅   |       |  ✅   |  (R)  | (R)       |   ✅   |
+| GZIP                                      |  ✅   |  ✅   |       |  ✅   |  (R)  | (R)       |   ✅   |
+| LZ4 (deprecated)                          |  ✅   |  ❌   |       |  ✅   |  ❌   | (R)       |   ❌   |
+| LZ4_RAW                                   |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| LZO                                       |  ❌   |  ❌   |       |  ❌   |  ❌   | ❌        |   ❌   |
+| SNAPPY                                    |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| ZSTD                                      |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
 
 ### Other format level features
 
-|                                           | C++   | Java  | Go    | Rust  | cuDF  | hyparquet |
-| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- |
-| xxHash-based bloom filters                |  (R)  |  ✅   |       |  ✅   |  (R)  |           |
-| Bloom filter length (1)                   |  (R)  |  ✅   |       |  ✅   |  (R)  |           |
-| Statistics min_value, max_value           |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| Page index                                |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |
-| Page CRC32 checksum                       |  ✅   |  ✅   |       |  ✅   |  ❌   | ❌        |
-| Modular encryption                        |  ✅   |  ✅   |       |  ❌   |  ❌   | ❌        |
-| Size statistics (2)                       |  ✅   |  ✅   |       |  ✅   |  ✅   |           |
-
+|                                           | C++   | Java  | Go    | Rust  | cuDF  | hyparquet | DuckDB |
+| ----------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- | ------ |
+| xxHash-based bloom filters                |  (R)  |  ✅   |       |  ✅   |  (R)  |           |   ✅   |
+| Bloom filter length (1)                   |  (R)  |  ✅   |       |  ✅   |  (R)  |           |   ✅   |
+| Statistics min_value, max_value           |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   ✅   |
+| Page index                                |  ✅   |  ✅   |       |  ✅   |  ✅   | (R)       |   (R)  |
+| Page CRC32 checksum                       |  ✅   |  ✅   |       |  ✅   |  ❌   | ❌        |   (R)  |
+| Modular encryption                        |  ✅   |  ✅   |       |  ❌   |  ❌   | ❌        |  ✅(*) |
+| Size statistics (2)                       |  ✅   |  ✅   |       |  ✅   |  ✅   |           |   (R)  |
 
 * \(1) In parquet.thrift: ColumnMetaData->bloom_filter_length
 
 * \(2) In parquet.thrift: ColumnMetaData->size_statistics
 
+* (*) Partial support
+
 ### High level data APIs for Parquet feature usage
 
-| Format                                       | C++   | Java  | Go    | Rust  | cuDF  | hyparquet |
-| -------------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- |
-| External column data (1)                     |  ✅   |  ✅   |       |  ❌   |  (W)  | ❌        |
-| Row group "Sorting column" metadata (2)      |  ✅   |  ❌   |       |  ✅   |  (W)  | ❌        |
-| Row group pruning using statistics           |  ❌   |  ✅   |       |  ✅   |  ✅   | ❌        |
-| Row group pruning using bloom filter         |  ❌   |  ✅   |       |  ✅   |  ✅   | ❌        |
-| Reading select columns only                  |  ✅   |  ✅   |       |  ✅   |  ✅   | ✅        |
-| Page pruning using statistics                |  ❌   |  ✅   |       |  ✅   |  ❌   | ❌        |
-
+| Format                                       | C++   | Java  | Go    | Rust  | cuDF  | hyparquet | DuckDB |
+| -------------------------------------------- | ----- | ----- | ----- | ----- | ----- | --------- | ------ |
+| External column data (1)                     |  ✅   |  ✅   |       |  ❌   |  (W)  | ❌        |   ❌   |
+| Row group "Sorting column" metadata (2)      |  ✅   |  ❌   |       |  ✅   |  (W)  | ❌        |   (R)  |
+| Row group pruning using statistics           |  ❌   |  ✅   |       |  ✅   |  ✅   | ❌        |   ✅   |
+| Row group pruning using bloom filter         |  ❌   |  ✅   |       |  ✅   |  ✅   | ❌        |   ✅   |
+| Reading select columns only                  |  ✅   |  ✅   |       |  ✅   |  ✅   | ✅        |   ✅   |
+| Page pruning using statistics                |  ❌   |  ✅   |       |  ✅   |  ❌   | ❌        |   ❌   |
 
 * \(1) In parquet.thrift: ColumnChunk->file_path
 


### PR DESCRIPTION
Heeding the [call](https://x.com/andrewlamb1111/status/1892180295945789900), we at DuckDB Labs (@hannes, @lnkuiper and me) worked on adding the implementation status of Parquet features in DuckDB.