### PR TITLE
Add Variant, Geometry, Geography types to implementation status page

### DIFF
--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -7,14 +7,15 @@ weight: 8
 This page summarizes the features supported by different Parquet
 implementations.
 
-*Note*: This is a work in progress and we would welcome help expanding its scope.
+*Note*: If you find out of date information, please help us improve the accuracy
+of this page by opening an issue or submitting a pull request.
 
 ### Legend
 The value in each box means:
 * ✅: supported
 * ❌: not supported
 * (R/W): partial reader/writer only support
-* (blank) no data
+* (blank): no data
 
 Implementations:
 * [arrow](https://github.com/apache/arrow/tree/main/cpp/src/parquet) (C++)
@@ -26,6 +27,11 @@ Implementations:
 * [duckdb](https://github.com/duckdb/duckdb) (C++)
 
 ### Physical types
+
+Physical types are defined by the [`enum Type` parquet.thrift]
+
+[`enum Type` parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L32
+
 
 | Data type                                 | arrow | parquet-java  | arrow-go | arrow-rs | cudf  | hyparquet | duckdb |
 | ----------------------------------------- | ----- | ------------- | -------- | -------- | ----- | --------- | ------ |
@@ -43,27 +49,35 @@ Implementations:
 
 ### Logical types
 
-| Data type                                 | arrow | parquet-java  | arrow-go | arrow-rs | cudf  | hyparquet | duckdb |
-| ----------------------------------------- | ----- | ------------- | -------- | -------- | ----- | --------- | ------ |
-| STRING                                    |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| ENUM                                      |  ❌   |  ✅           |  ✅      |  ✅ (1)  |  ❌   |  ✅       |   ✅   |
-| UUID                                      |  ❌   |  ✅           |  ✅      |  ✅ (1)  |  ❌   |  ✅       |   ✅   |
-| 8, 16, 32, 64 bit signed and unsigned INT |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| DECIMAL (INT32)                           |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| DECIMAL (INT64)                           |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| DECIMAL (BYTE_ARRAY)                      |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   (R)  |
-| DECIMAL (FIXED_LEN_BYTE_ARRAY)            |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| DATE                                      |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| TIME (INT32)                              |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| TIME (INT64)                              |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| TIMESTAMP (INT64)                         |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| INTERVAL                                  |  ✅   |  ✅ (1)       |  ✅      |  ✅      |  ❌   |  ✅       |   ✅   |
-| JSON                                      |  ✅   |  ✅ (1)       |  ✅      |  ✅ (1)  |  ❌   |  ✅       |   ✅   |
-| BSON                                      |  ❌   |  ✅ (1)       |  ✅      |  ✅ (1)  |  ❌   |  ❌       |   ❌   |
-| LIST                                      |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  (R)      |   ✅   |
-| MAP                                       |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  (R)      |   ✅   |
-| UNKNOWN (always null)                     |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
-| FLOAT16                                   |  ✅   |  ✅ (1)       |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
+Logical types are defined by the [`union LogicalType` in parquet.thrift] and described in [LogicalTypes.md]
+
+[`union LogicalType` in parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L471
+[LogicalTypes.md]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+
+| Data type                                 | arrow | parquet-java | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
+|-------------------------------------------|------| ------- | ------- | ------- | ---- | -------- |--------|
+| STRING                                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| ENUM                                      | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| UUID                                      | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| 8, 16, 32, 64 bit signed and unsigned INT | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT32)                           | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT64)                           | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (BYTE_ARRAY)                      | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | (R)    |
+| DECIMAL (FIXED_LEN_BYTE_ARRAY)            | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| FLOAT16                                   | ✅    |  ✅ (1) |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DATE                                      | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIME (INT32)                              | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIME (INT64)                              | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIMESTAMP (INT64)                         | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| INTERVAL                                  | ✅    |  ✅ (1) |  ✅     |  ✅     |  ❌  |  ✅      | ✅      |
+| JSON                                      | ✅    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| BSON                                      | ❌    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ❌      | ❌      |
+| VARIANT                                   |      |        |        |        |     |         |        |
+| GEOMETRY                                  |      |        |        |        |     |         |        |
+| GEOGRAPHY                                 |      |        |        |        |     |         |        |
+| LIST                                      | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
+| MAP                                       | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
+| UNKNOWN (always null)                     | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
 
 * \(1) Only supported to use its annotated physical type
 

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -73,8 +73,8 @@ Logical types are defined by the [`union LogicalType` in parquet.thrift] and des
 | JSON                                    | ✅    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ✅      | ✅      |
 | BSON                                    | ❌    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ❌      | ❌      |
 | [VARIANT]                               |       |              |  ✅     |  ✅       |      |  ❌      | ✅      |
-| [GEOMETRY]                              |       |              |         |           |      |  ✅      | ✅      |
-| [GEOGRAPHY]                             |       |              |         |           |      |  ✅      | ✅      |
+| [GEOMETRY]                              | ✅    |  ✅          |         |  ✅       |      |  ✅      | ✅      |
+| [GEOGRAPHY]                             | ✅    |  ✅          |         |  ✅       |      |  ✅      | ✅      |
 | LIST                                    | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
 | MAP                                     | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
 | UNKNOWN (always null)                   | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -55,29 +55,29 @@ Logical types are defined by the [`union LogicalType` in parquet.thrift] and des
 [LogicalTypes.md]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
 
 | Data type                               | arrow | parquet-java | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
-|-----------------------------------------|------| ------------- | ------- | ------- | ---- | -------- |--------|
-| STRING                                  | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| ENUM                                    | ❌    |  ✅          |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| UUID                                    | ❌    |  ✅          |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| 8, 16, 32, 64 bit signed and unsigned INT | ✅  |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (INT32)                         | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (INT64)                         | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (BYTE_ARRAY)                    | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | (R)    |
-| DECIMAL (FIXED_LEN_BYTE_ARRAY)          | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| FLOAT16                                 | ✅    |  ✅ (1)      |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DATE                                    | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIME (INT32)                            | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIME (INT64)                            | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIMESTAMP (INT64)                       | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| INTERVAL                                | ✅    |  ✅ (1)      |  ✅     |  ✅     |  ❌  |  ✅      | ✅      |
-| JSON                                    | ✅    |  ✅ (1)      |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| BSON                                    | ❌    |  ✅ (1)      |  ✅     |  ✅ (1) |  ❌  |  ❌      | ❌      |
-| [VARIANT]                               |       |              |  ✅     |  ✅     |      |          |         |
-| [GEOMETRY]                              |       |              |         |         |      |          |         |
-| [GEOGRAPHY]                             |       |              |         |         |      |          |         |
-| LIST                                    | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
-| MAP                                     | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
-| UNKNOWN (always null)                   | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+|-----------------------------------------|------| ------------- | ------- | --------- | ---- | -------- |--------|
+| STRING                                  | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| ENUM                                    | ❌    |  ✅          |  ✅     |  ✅ (1)   |  ❌  |  ✅      | ✅      |
+| UUID                                    | ❌    |  ✅          |  ✅     |  ✅ (1)   |  ❌  |  ✅      | ✅      |
+| 8, 16, 32, 64 bit signed and unsigned INT | ✅  |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT32)                         | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT64)                         | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| DECIMAL (BYTE_ARRAY)                    | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | (R)    |
+| DECIMAL (FIXED_LEN_BYTE_ARRAY)          | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| FLOAT16                                 | ✅    |  ✅ (1)      |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| DATE                                    | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| TIME (INT32)                            | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| TIME (INT64)                            | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| TIMESTAMP (INT64)                       | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
+| INTERVAL                                | ✅    |  ✅ (1)      |  ✅     |  ✅       |  ❌  |  ✅      | ✅      |
+| JSON                                    | ✅    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ✅      | ✅      |
+| BSON                                    | ❌    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ❌      | ❌      |
+| [VARIANT]                               |       |              |  ✅     |  ✅       |      |  ❌      |         |
+| [GEOMETRY]                              |       |              |         |           |      |  ✅      |         |
+| [GEOGRAPHY]                             |       |              |         |           |      |  ✅      |         |
+| LIST                                    | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
+| MAP                                     | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
+| UNKNOWN (always null)                   | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |
 
 * \(1) Only supported to use its annotated physical type
 

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -72,9 +72,9 @@ Logical types are defined by the [`union LogicalType` in parquet.thrift] and des
 | INTERVAL                                | ✅    |  ✅ (1)      |  ✅     |  ✅       |  ❌  |  ✅      | ✅      |
 | JSON                                    | ✅    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ✅      | ✅      |
 | BSON                                    | ❌    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ❌      | ❌      |
-| [VARIANT]                               |       |              |  ✅     |  ✅       |      |  ❌      | ✅      |
-| [GEOMETRY]                              | ✅    |  ✅          |         |  ✅       |      |  ✅      | ✅      |
-| [GEOGRAPHY]                             | ✅    |  ✅          |         |  ✅       |      |  ✅      | ✅      |
+| [VARIANT]                               |       |  ✅          |  ✅     |  ✅       |  ❌  |  ❌      | ✅      |
+| [GEOMETRY]                              | ✅    |  ✅          |  ❌     |  ✅       |  ❌  |  ✅      | ✅      |
+| [GEOGRAPHY]                             | ✅    |  ✅          |  ❌     |  ✅       |  ❌  |  ✅      | ✅      |
 | LIST                                    | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
 | MAP                                     | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
 | UNKNOWN (always null)                   | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -28,9 +28,9 @@ Implementations:
 
 ### Physical types
 
-Physical types are defined by the [`enum Type` parquet.thrift]
+Physical types are defined by the [`enum Type` in parquet.thrift]
 
-[`enum Type` parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L32
+[`enum Type` in parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L32
 
 
 | Data type                                 | arrow | parquet-java  | arrow-go | arrow-rs | cudf  | hyparquet | duckdb |

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -72,9 +72,9 @@ Logical types are defined by the [`union LogicalType` in parquet.thrift] and des
 | INTERVAL                                | ✅    |  ✅ (1)      |  ✅     |  ✅       |  ❌  |  ✅      | ✅      |
 | JSON                                    | ✅    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ✅      | ✅      |
 | BSON                                    | ❌    |  ✅ (1)      |  ✅     |  ✅ (1)   |  ❌  |  ❌      | ❌      |
-| [VARIANT]                               |       |              |  ✅     |  ✅       |      |  ❌      |         |
-| [GEOMETRY]                              |       |              |         |           |      |  ✅      |         |
-| [GEOGRAPHY]                             |       |              |         |           |      |  ✅      |         |
+| [VARIANT]                               |       |              |  ✅     |  ✅       |      |  ❌      | ✅      |
+| [GEOMETRY]                              |       |              |         |           |      |  ✅      | ✅      |
+| [GEOGRAPHY]                             |       |              |         |           |      |  ✅      | ✅      |
 | LIST                                    | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
 | MAP                                     | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  (R)     | ✅      |
 | UNKNOWN (always null)                   | ✅    |  ✅          |  ✅     |  ✅       |  ✅  |  ✅      | ✅      |

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -54,32 +54,37 @@ Logical types are defined by the [`union LogicalType` in parquet.thrift] and des
 [`union LogicalType` in parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L471
 [LogicalTypes.md]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
 
-| Data type                                 | arrow | parquet-java | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
-|-------------------------------------------|------| ------- | ------- | ------- | ---- | -------- |--------|
-| STRING                                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| ENUM                                      | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| UUID                                      | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| Data type                               | arrow | parquet-java | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
+|-----------------------------------------|------| ------- | ------- | ------- | ---- | -------- |--------|
+| STRING                                  | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| ENUM                                    | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| UUID                                    | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
 | 8, 16, 32, 64 bit signed and unsigned INT | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (INT32)                           | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (INT64)                           | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (BYTE_ARRAY)                      | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | (R)    |
-| DECIMAL (FIXED_LEN_BYTE_ARRAY)            | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| FLOAT16                                   | ✅    |  ✅ (1) |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DATE                                      | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIME (INT32)                              | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIME (INT64)                              | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIMESTAMP (INT64)                         | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| INTERVAL                                  | ✅    |  ✅ (1) |  ✅     |  ✅     |  ❌  |  ✅      | ✅      |
-| JSON                                      | ✅    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| BSON                                      | ❌    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ❌      | ❌      |
-| VARIANT                                   |      |        |        |        |     |         |        |
-| GEOMETRY                                  |      |        |        |        |     |         |        |
-| GEOGRAPHY                                 |      |        |        |        |     |         |        |
-| LIST                                      | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
-| MAP                                       | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
-| UNKNOWN (always null)                     | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT32)                         | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT64)                         | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (BYTE_ARRAY)                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | (R)    |
+| DECIMAL (FIXED_LEN_BYTE_ARRAY)          | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| FLOAT16                                 | ✅    |  ✅ (1) |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DATE                                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIME (INT32)                            | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIME (INT64)                            | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIMESTAMP (INT64)                       | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| INTERVAL                                | ✅    |  ✅ (1) |  ✅     |  ✅     |  ❌  |  ✅      | ✅      |
+| JSON                                    | ✅    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| BSON                                    | ❌    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ❌      | ❌      |
+| [VARIANT]                               |      |        |        |        |     |         |        |
+| [GEOMETRY]                              |      |        |        |        |     |         |        |
+| [GEOGRAPHY]                             |      |        |        |        |     |         |        |
+| LIST                                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
+| MAP                                     | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
+| UNKNOWN (always null)                   | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
 
 * \(1) Only supported to use its annotated physical type
+
+[VARIANT]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
+[GEOMETRY]: https://github.com/apache/parquet-format/blob/master/Geospatial.md#logical-types
+[GEOGRAPHY]: https://github.com/apache/parquet-format/blob/master/Geospatial.md#logical-types
+
 
 ### Encodings
 

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -55,29 +55,29 @@ Logical types are defined by the [`union LogicalType` in parquet.thrift] and des
 [LogicalTypes.md]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
 
 | Data type                               | arrow | parquet-java | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
-|-----------------------------------------|------| ------- | ------- | ------- | ---- | -------- |--------|
-| STRING                                  | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| ENUM                                    | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| UUID                                    | ❌    |  ✅     |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| 8, 16, 32, 64 bit signed and unsigned INT | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (INT32)                         | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (INT64)                         | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DECIMAL (BYTE_ARRAY)                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | (R)    |
-| DECIMAL (FIXED_LEN_BYTE_ARRAY)          | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| FLOAT16                                 | ✅    |  ✅ (1) |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| DATE                                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIME (INT32)                            | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIME (INT64)                            | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| TIMESTAMP (INT64)                       | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
-| INTERVAL                                | ✅    |  ✅ (1) |  ✅     |  ✅     |  ❌  |  ✅      | ✅      |
-| JSON                                    | ✅    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
-| BSON                                    | ❌    |  ✅ (1) |  ✅     |  ✅ (1) |  ❌  |  ❌      | ❌      |
-| [VARIANT]                               |      |        |        |        |     |         |        |
-| [GEOMETRY]                              |      |        |        |        |     |         |        |
-| [GEOGRAPHY]                             |      |        |        |        |     |         |        |
-| LIST                                    | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
-| MAP                                     | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
-| UNKNOWN (always null)                   | ✅    |  ✅     |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+|-----------------------------------------|------| ------------- | ------- | ------- | ---- | -------- |--------|
+| STRING                                  | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| ENUM                                    | ❌    |  ✅          |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| UUID                                    | ❌    |  ✅          |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| 8, 16, 32, 64 bit signed and unsigned INT | ✅  |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT32)                         | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (INT64)                         | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DECIMAL (BYTE_ARRAY)                    | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | (R)    |
+| DECIMAL (FIXED_LEN_BYTE_ARRAY)          | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| FLOAT16                                 | ✅    |  ✅ (1)      |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| DATE                                    | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIME (INT32)                            | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIME (INT64)                            | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| TIMESTAMP (INT64)                       | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
+| INTERVAL                                | ✅    |  ✅ (1)      |  ✅     |  ✅     |  ❌  |  ✅      | ✅      |
+| JSON                                    | ✅    |  ✅ (1)      |  ✅     |  ✅ (1) |  ❌  |  ✅      | ✅      |
+| BSON                                    | ❌    |  ✅ (1)      |  ✅     |  ✅ (1) |  ❌  |  ❌      | ❌      |
+| [VARIANT]                               |       |              |  ✅     |  ✅     |      |          |         |
+| [GEOMETRY]                              |       |              |         |         |      |          |         |
+| [GEOGRAPHY]                             |       |              |         |         |      |          |         |
+| LIST                                    | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
+| MAP                                     | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  (R)     | ✅      |
+| UNKNOWN (always null)                   | ✅    |  ✅          |  ✅     |  ✅     |  ✅  |  ✅      | ✅      |
 
 * \(1) Only supported to use its annotated physical type
 


### PR DESCRIPTION
- Closes https://github.com/apache/parquet-site/issues/118

## Rationale
Three new logical types have been added to the Parquet specification. Let's ensure they are listed in the implementation status matrix

# Changes:
1. Add entries for Variant, Geometry, Geography types
2. Add links to relevant parts of the spec 

Here is a preview:
<img width="698" height="1105" alt="Screenshot 2025-10-22 at 7 01 39 AM" src="https://github.com/user-attachments/assets/ce04394c-6267-4705-b6f9-8d3b02d62015" />
