### PR TITLE
Add DataPageHeaderV2 ("V2 Data Pages") to implementation status

### DIFF
--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -117,7 +117,7 @@ Compressions are defined by the [`enum CompressionCodec` in parquet.thrift] and 
 | Page CRC32 checksum             |  ✅   |  ✅           |  ❌    |  ✅      |  ❌ |  ❌       |  (R) |
 | [Modular encryption]            |  ✅   |  ✅           |  ✅    |  ✅      |  ❌ |  ❌       | ✅ (*) |
 | Size statistics (2)             |  ✅   |  ✅           |  (R)  |  ✅      |  ✅ |           |  (R) |
-| Data Page V2 (3)                |  ✅   |  ✅           |       |  ✅      |   |           |     |
+| Data Page V2 (3)                |  ✅   |  ✅           |  ✅   |  ✅      |   |           |     |
 
 * \(1) In [parquet.thrift]: ColumnMetaData->bloom_filter_length
 

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -109,15 +109,15 @@ Compressions are defined by the [`enum CompressionCodec` in parquet.thrift] and 
 ### Other format level features
 
 | Feature                         | arrow | parquet-java  | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
-|---------------------------------| ----- | ------------- | ----- | -------- | -- | --------- | --- |
-| [xxHash-based bloom filters]    |  (R)  |  ✅           |  ✅    |  ✅      |  (R) |           |  ✅  |
-| Bloom filter length (1)         |  (R)  |  ✅           |  ✅    |  ✅      |  (R) |           |  ✅  |
-| Statistics min_value, max_value |  ✅   |  ✅           |  ✅    |  ✅      |  ✅ |  ✅       |  ✅  |
-| [Page index]                    |  ✅   |  ✅           |  ✅    |  ✅      |  ✅ |  (R)      |  (R) |
-| Page CRC32 checksum             |  ✅   |  ✅           |  ❌    |  ✅      |  ❌ |  ❌       |  (R) |
-| [Modular encryption]            |  ✅   |  ✅           |  ✅    |  ✅      |  ❌ |  ❌       | ✅ (*) |
-| Size statistics (2)             |  ✅   |  ✅           |  (R)  |  ✅      |  ✅ |           |  (R) |
-| Data Page V2 (3)                |  ✅   |  ✅           |  ✅   |  ✅      |  ✅  |  ✅          |  ✅    |
+|---------------------------------| ----- | ------------- | -------- | -------- | ---- | --------- | ------ |
+| [xxHash-based bloom filters]    |  (R)  |  ✅           |  ✅      |  ✅      |  (R) |           |  ✅    |
+| Bloom filter length (1)         |  (R)  |  ✅           |  ✅      |  ✅      |  (R) |           |  ✅    |
+| Statistics min_value, max_value |  ✅   |  ✅           |  ✅      |  ✅      |  ✅  |  ✅       |  ✅    |
+| [Page index]                    |  ✅   |  ✅           |  ✅      |  ✅      |  ✅  |  (R)      |  (R)   |
+| Page CRC32 checksum             |  ✅   |  ✅           |  ❌      |  ✅      |  ❌  |  ❌       |  (R)   |
+| [Modular encryption]            |  ✅   |  ✅           |  ✅      |  ✅      |  ❌  |  ❌       |  ✅ (*) |
+| Size statistics (2)             |  ✅   |  ✅           |  (R)     |  ✅      |  ✅  |           |  (R)   |
+| Data Page V2 (3)                |  ✅   |  ✅           |  ✅      |  ✅      |  ✅  |  ✅       |  ✅    |
 
 * \(1) In [parquet.thrift]: ColumnMetaData->bloom_filter_length
 

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -90,7 +90,7 @@ Encodings are defined by the [`enum Encoding` in parquet.thrift] and described i
 
 ### Compressions
 
-Compressions are defined by the [`enum CompressionCodec` in parquet.thrift] and described in [Encodings.md]
+Compressions are defined by the [`enum CompressionCodec` in parquet.thrift] and described in [Compression.md]
 
 [`enum CompressionCodec` in parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L642
 [Compression.md]: https://github.com/apache/parquet-format/blob/master/Compression.md

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -117,7 +117,7 @@ Compressions are defined by the [`enum CompressionCodec` in parquet.thrift] and 
 | Page CRC32 checksum             |  ✅   |  ✅           |  ❌    |  ✅      |  ❌ |  ❌       |  (R) |
 | [Modular encryption]            |  ✅   |  ✅           |  ✅    |  ✅      |  ❌ |  ❌       | ✅ (*) |
 | Size statistics (2)             |  ✅   |  ✅           |  (R)  |  ✅      |  ✅ |           |  (R) |
-| Data Page V2 (3)                |  ✅   |  ✅           |  ✅   |  ✅      |   |           |     |
+| Data Page V2 (3)                |  ✅   |  ✅           |  ✅   |  ✅      |  ✅  |  ✅          |  ✅    |
 
 * \(1) In [parquet.thrift]: ColumnMetaData->bloom_filter_length
 

--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -69,6 +69,11 @@ Implementations:
 
 ### Encodings
 
+Encodings are defined by the [`enum Encoding` in parquet.thrift] and described in [Encodings.md]
+
+[`enum Encoding` in parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L566
+[Encodings.md]: https://github.com/apache/parquet-format/blob/master/Encodings.md
+
 | Encoding                                  | arrow | parquet-java  | arrow-go | arrow-rs | cudf  | hyparquet | duckdb |
 | ----------------------------------------- | ----- | ------------- | -------- | -------- | ----- | --------- | ------ |
 | PLAIN                                     |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
@@ -85,6 +90,11 @@ Implementations:
 
 ### Compressions
 
+Compressions are defined by the [`enum CompressionCodec` in parquet.thrift] and described in [Encodings.md]
+
+[`enum CompressionCodec` in parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L642
+[Compression.md]: https://github.com/apache/parquet-format/blob/master/Compression.md
+
 | Compression                               | arrow | parquet-java  | arrow-go | arrow-rs | cudf  | hyparquet | duckdb |
 | ----------------------------------------- | ----- | ------------- | -------- | -------- | ----- | --------- | ------ |
 | UNCOMPRESSED                              |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |   ✅   |
@@ -98,19 +108,28 @@ Implementations:
 
 ### Other format level features
 
-| Feature                                   | arrow | parquet-java  | arrow-go | arrow-rs | cudf  | hyparquet | duckdb |
-| ----------------------------------------- | ----- | ------------- | -------- | -------- | ----- | --------- | ------ |
-| xxHash-based bloom filters                |  (R)  |  ✅           |  ✅      |  ✅      |  (R)  |           |  ✅    |
-| Bloom filter length (1)                   |  (R)  |  ✅           |  ✅      |  ✅      |  (R)  |           |  ✅    |
-| Statistics min_value, max_value           |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  ✅       |  ✅    |
-| Page index                                |  ✅   |  ✅           |  ✅      |  ✅      |  ✅   |  (R)      |  (R)   |
-| Page CRC32 checksum                       |  ✅   |  ✅           |  ❌      |  ✅      |  ❌   |  ❌       |  (R)   |
-| Modular encryption                        |  ✅   |  ✅           |  ✅      |  ✅      |  ❌   |  ❌       | ✅ (*) |
-| Size statistics (2)                       |  ✅   |  ✅           |  (R)     |  ✅      |  ✅   |           |  (R)   |
+| Feature                         | arrow | parquet-java  | arrow-go | arrow-rs | cudf | hyparquet | duckdb |
+|---------------------------------| ----- | ------------- | ----- | -------- | -- | --------- | --- |
+| [xxHash-based bloom filters]    |  (R)  |  ✅           |  ✅    |  ✅      |  (R) |           |  ✅  |
+| Bloom filter length (1)         |  (R)  |  ✅           |  ✅    |  ✅      |  (R) |           |  ✅  |
+| Statistics min_value, max_value |  ✅   |  ✅           |  ✅    |  ✅      |  ✅ |  ✅       |  ✅  |
+| [Page index]                    |  ✅   |  ✅           |  ✅    |  ✅      |  ✅ |  (R)      |  (R) |
+| Page CRC32 checksum             |  ✅   |  ✅           |  ❌    |  ✅      |  ❌ |  ❌       |  (R) |
+| [Modular encryption]            |  ✅   |  ✅           |  ✅    |  ✅      |  ❌ |  ❌       | ✅ (*) |
+| Size statistics (2)             |  ✅   |  ✅           |  (R)  |  ✅      |  ✅ |           |  (R) |
+| Data Page V2 (3)                |  ✅   |  ✅           |       |  ✅      |   |           |     |
 
-* \(1) In parquet.thrift: ColumnMetaData->bloom_filter_length
+* \(1) In [parquet.thrift]: ColumnMetaData->bloom_filter_length
 
-* \(2) In parquet.thrift: ColumnMetaData->size_statistics
+* \(2) In [parquet.thrift]: ColumnMetaData->size_statistics
+
+* \(3) In [parquet.thrift]: DataPageHeaderV2
+
+[xxHash-based bloom filters]: https://github.com/apache/parquet-format/blob/master/BloomFilter.md
+[parquet.thrift]: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift
+[Page index]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+[Modular encryption]: https://github.com/apache/parquet-format/blob/master/Encryption.md
+
 
 * (*) Partial support
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "homepage": "https://github.com/apache/parquet-site#readme",
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.4.2",
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6",
-    "postcss-cli": "^11.0.1"
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.35",
+    "postcss-cli": "^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "homepage": "https://github.com/apache/parquet-site#readme",
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.4.2",
-    "autoprefixer": "^10.4.18",
-    "postcss": "^8.4.35",
-    "postcss-cli": "^11.0.0"
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "postcss-cli": "^11.0.1"
   }
 }


### PR DESCRIPTION
# Rationale

As suggested by @pitrou on the mailing list: https://lists.apache.org/thread/w6fjh4t415fw4y5q7l7nxb34ccbdsoxs

> Someone has to add V2 data pages to
> https://github.com/apache/parquet-site/blob/production/content/en/docs/File%20Format/implementationstatus.md

The longer story is that the V2 data pages are not widely adopted (yet); Making the current state clearer will help adoption

# Changes
1. Add a new row for V2 data pages (noting that C++/Rust/Java all support them)
2. Add additional links to other concepts / documentation

Here is a rendered preview:
<img width="733" height="1130" alt="Screenshot 2025-10-22 at 9 06 58 AM" src="https://github.com/user-attachments/assets/e191fc54-b6af-47c8-aa01-3bfad1cf820b" />
