### PR TITLE
Minor: change Download to Releases on landing page

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -7,7 +7,7 @@ title: Parquet
   Documentation <i class="fas fa-arrow-alt-circle-right ms-2"></i>
 </a>
 <a class="btn btn-lg btn-secondary me-3 mb-4" href="/blog/">
-  Download <i class="fab fa-github ms-2 "></i>
+  Releases <i class="fa fa-arrow-circle-down ms-2 "></i>
 </a>
 <p class="lead mt-5">
 Apache Parquet is an open source, column-oriented data file format designed for efficient data storage and retrieval. 

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Release"
-linkTitle: "Release"
+title: "Releases"
+linkTitle: "Releases"
 menu:
   main:
     weight: 3


### PR DESCRIPTION
# Rationale

The "Download" button on the main page https://parquet.apache.org/ is confusing:

1. It does not actually lead to a download (it links to https://parquet.apache.org/blog which has parquet-java release announcements)
2. It has a github icon (but it doesn't lead to github)

# Changes:
1. Rename button to Releases
2. Fix title of `/blog` to `Releases` (from `Release`)

Here is how it looks now

<img width="1727" height="605" alt="Screenshot 2025-11-03 at 5 26 56 AM" src="https://github.com/user-attachments/assets/03479a1d-38c8-407c-998c-511357341be6" />
