### PR TITLE
Update community page and links

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -18,7 +18,7 @@ It provides high performance compression and encoding schemes to handle complex 
 
 
 {{< blocks/section color="white" type="row">}}
-{{% blocks/feature icon="fab fa-jira" title="Documentation" url="docs" %}}
+{{% blocks/feature icon="fa fa-book" title="Documentation" url="docs" %}}
 Browse project documentation including the format specification.
 {{% /blocks/feature %}}
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -16,11 +16,11 @@ enableGitInfo = true
 # Comment out to enable taxonomies in Docsy
 # disableKinds = ["taxonomy", "taxonomyTerm"]
 
-# Link to Github
+# Link to Github (top right link in navbar)
 [[menu.main]]
     name = "GitHub"
     weight = 50
-    url = "https://github.com/apache/parquet-java/"
+    url = "https://github.com/apache/parquet-format/"
     pre = "<i class='fab fa-github'></i>"
 
 # Configure how URLs look like per section.
@@ -162,41 +162,11 @@ enable = false
   url = "https://lists.apache.org/list.html?dev@parquet.apache.org"
   icon = "fa fa-box-archive"
   desc = "View archives of past discussions."
-[[params.links.user]]
-  name ="Twitter"
-  url = "https://twitter.com/ApacheParquet"
-  icon = "fab fa-twitter"
-  desc = "Follow us on Twitter to get the latest news!"
-[[params.links.user]]
-  name = "Stack Overflow"
-  url = "https://stackoverflow.com/questions/tagged/parquet"
-  icon = "fab fa-stack-overflow"
-  desc = "Practical questions and curated answers"
-[[params.links.user]]
-  name = "Parquet Community Sync"
-  url = "https://groups.google.com/g/apache-parquet-community-sync/about"
-  icon = "fa fa-calendar"
-  desc = "Join for calendar events and community sync"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
-[[params.links.developer]]
-  name = "GitHub"
-  url = "https://github.com/apache/parquet-java"
-  icon = "fab fa-github"
-  desc = "Development takes place here!"
-[[params.links.developer]]
-  name = "Slack"
-  url = "https://the-asf.slack.com/"
-  icon = "fab fa-slack"
-  desc = "Chat with other project developers"
-[[params.links.developer]]
-  name = "Developer mailing list"
-  url = "mailto:dev@parquet.apache.org"
-  icon = "fa fa-envelope"
-  desc = "Discuss development issues around the project"
 [[params.links.developer]]
   name = "Parquet specification"
   url = "https://github.com/apache/parquet-format"
-  icon = "fas fa-jira"
+  icon = "fab fa-github"
   desc = "Parquet specification"
 
 [module]

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -10,7 +10,7 @@
         <div class="container text-center td-arrow-down">
       <span class="h4 mb-0">
         <h1>Join the Apache Parquet Community</h1>
-          <h2>"If you want to go fast go alone, if you want to go far go together"</h2>
+          <h2>"If you want to go fast, go alone; if you want to go far, go together"</h2>
 
         <p>Apache Parquet is part of the
             <a href="https://www.apache.org">Apache Software Foundation</a>

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,0 +1,83 @@
+{{ define "main" -}}
+
+<!-- based off of https://github.com/google/docsy/blob/main/layouts/community/list.html -->
+
+<div><a class="td-offset-anchor"></a></div>
+<section
+        class="row td-box td-box--primary position-relative td-box--height-auto"
+>
+    <div class="col-12">
+        <div class="container text-center td-arrow-down">
+      <span class="h4 mb-0">
+        <h1>Join the Apache Parquet Community</h1>
+        <p>Apache Parquet is part of the
+            <a href="https://www.apache.org">Apache Software Foundation</a>
+            and is developed and maintained by a contributors from around the world.
+            We'd love you to join us! Here's a few ways to find out what's happening and get involved</p>
+      </span>
+        </div>
+    </div>
+</section>
+
+<!--
+In the real docsy theme, the content is generated via the partial "community_links.html".
+Here we inline it for simplicity (aka I am not enough of a hugo expert
+to figure out how to do it "correctly")
+-->
+<!--
+{{ partial "community_links.html" . -}}
+-->
+
+<section class="row td-box td-box--white td-box--height-auto linkbox">
+    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+        <h2>Learn and Connect</h2>
+        <p><b>Development Mailing List</b>
+            Most Parquet related discussion occurs on the developer mailing list,
+            <a href="mailto:dev@parquet.apache.org">dev@parquet.apache.org</a>:
+        </p>
+        <ul>
+            <li title="Subscribe">
+                <a href="mailto:dev-subscribe@parquet.apache.org"><i class="fa fa-envelope-circle-check"></i> Subscribe</a>:
+                Send an email to subscribe to the list
+            </li>
+            <li title="Post">
+                <a href="mailto:dev@parquet.apache.org"><i class="fa fa-envelope"></i> Post</a>:
+                Send a message to the list
+            </li>
+            <li title="Archives">
+                <a href="https://lists.apache.org/list.html?dev@parquet.apache.org"><i class="fa fa-box-archive"></i> Archives</a>:
+                View archives of past discussions.
+            </li>
+        </ul>
+        <p> We also hold bi-weekly video calls to coordinate efforts.
+            Everybody is welcome to bring a topic or just listen in.
+            We send meeting reminders with links to the
+            developer mailing list before each meeting, and a summary after each meeting.
+            See
+            <a href="https://lists.apache.org/thread/bjdkscmx7zvgfbw0wlfttxy8h6v3f71t">here</a>
+            for more details on how the meeting is run.
+        </p>
+        <ul>
+            <li title="Subscribe">
+                <a href="https://groups.google.com/g/apache-parquet-community-sync/about"><i class="fa fa-users"></i> Join Group</a>:
+                Join the Google group to access the calendar invite, agenda, and recordings of past calls.
+            </li>
+        </ul>
+    </div>
+
+    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+        <h2>Develop and Contribute</h2>
+        <p>If you want to get more involved by contributing to Parquet, please see our
+            <a href="/docs/contribution-guidelines/">Developer Guide.</a>
+        </p>
+    </div>
+</section>
+
+
+{{ with .Content -}}
+<div class="td-content">
+    {{ . }}
+</div>
+{{- end -}}
+
+{{ end }}

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -10,10 +10,12 @@
         <div class="container text-center td-arrow-down">
       <span class="h4 mb-0">
         <h1>Join the Apache Parquet Community</h1>
+          <h2>"If you want to go fast go alone, if you want to go far go together"</h2>
+
         <p>Apache Parquet is part of the
             <a href="https://www.apache.org">Apache Software Foundation</a>
             and is developed and maintained by a contributors from around the world.
-            We'd love you to join us! Here's a few ways to find out what's happening and get involved</p>
+            We'd love you to join us!</p>
       </span>
         </div>
     </div>
@@ -55,7 +57,11 @@ to figure out how to do it "correctly")
             developer mailing list before each meeting, and a summary after each meeting.
             See
             <a href="https://lists.apache.org/thread/bjdkscmx7zvgfbw0wlfttxy8h6v3f71t">here</a>
-            for more details on how the meeting is run.
+            for more details on how the meeting is run, the
+            <a href="https://www.youtube.com/playlist?list=PLsc4WKPCP34Q6RFVeqEVXJshpAReTmgUj">archives</a>
+            for recordings of past meetings, and
+            <a href="https://docs.google.com/document/d/e/2PACX-1vSDHW7gvG8eO6aIxaIVPrZSqYYhtRDb5W1imnbpM4QRYNPsTwEO1fU5z7SEhVIFa4YqWJeSRJ9tcXYS">here</a>
+            for agendas of past meetings.
         </p>
         <ul>
             <li title="Subscribe">


### PR DESCRIPTION
- Closes https://github.com/apache/parquet-site/issues/71

Per @julienledem  on https://lists.apache.org/thread/gdy1lpdcns7yj5y2r91ljjlgo72yb4g1

> If someone wants to give a facelift to the community page on the website,
> that would be welcome:
> https://parquet.apache.org/community/
> I don't think the slack is active. We should probably highlight the list
> and the bi-weekly sync as the two main means of communication.


# Changes
Updated the community page to reflect the mailing list and sync calls as primary communication mechanism

<img width="1713" height="730" alt="Screenshot 2025-11-03 at 6 51 50 AM" src="https://github.com/user-attachments/assets/bc061844-2330-4224-a3b6-d79538aefce4" />


For reference here is the current state of https://parquet.apache.org/community/

<img width="1728" height="645" alt="Screenshot 2025-11-03 at 6 40 26 AM" src="https://github.com/user-attachments/assets/59a87be8-d4c7-4f8c-8f58-a5670648073f" />
