### PR TITLE
Minor: Backlink to website, Update introductory wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Parquet Website
 
-This website is built / powered by [Hugo](https://gohugo.io/), and extended from the [Docsy Theme](https://www.docsy.dev/).
+This repository contains the source code for https://parquet.apache.org/
 
-The following steps assume that you have `hugo` installed and working. 
+This website is built / powered by [Hugo](https://gohugo.io/) with the [Docsy Theme](https://www.docsy.dev/).
+
+The following steps assume that you have `hugo` installed and working.
 You can also use docker, see the [Docker section](#docker) for more information.
 
 ## Building and Running Locally


### PR DESCRIPTION
I think it is important to provide a back link to what website is driven by this repo

While I was making a PR I also found the first sentence somewhat confusing so I am proposing a drive by cleanup

You can see a rendered preview of the changes here: https://github.com/alamb/parquet-site/blob/alamb/add_homing_link/README.md