### PR TITLE
Update main page landing page links to community

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -22,8 +22,8 @@ It provides high performance compression and encoding schemes to handle complex 
 Browse project documentation including the format specification.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/apache/parquet-java" %}}
-We do a [Pull Request](https://github.com/apache/parquet-java/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="community" %}}
+Join the community to help us improve Parquet together. New users and contributors are always welcome!
 {{% /blocks/feature %}}
 
 


### PR DESCRIPTION
Closes https://github.com/apache/parquet-site/issues/137

Some of the main links on https://parquet.apache.org/ bring you directly to parquet-java

<img width="626" height="436" alt="Image" src="https://github.com/user-attachments/assets/f288a521-18b5-417e-af86-6f85720209b1" />

As we focus the website on the broader community I think it would be better if these links brought people to the overall community page

This PR changes it to this 

<img width="816" height="374" alt="Screenshot 2025-11-12 at 6 46 22 AM" src="https://github.com/user-attachments/assets/e5960b3f-4e00-4aed-9710-fe9c872cd71e" />

Which links to https://parquet.apache.org/community/ rather than parquet-java
