### PR TITLE
Update Google Docs link for meeting agendas

### DIFF
--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -60,7 +60,7 @@ to figure out how to do it "correctly")
             for more details on how the meeting is run, the
             <a href="https://www.youtube.com/playlist?list=PLsc4WKPCP34Q6RFVeqEVXJshpAReTmgUj">archives</a>
             for recordings of past meetings, and
-            <a href="https://docs.google.com/document/d/e/2PACX-1vSDHW7gvG8eO6aIxaIVPrZSqYYhtRDb5W1imnbpM4QRYNPsTwEO1fU5z7SEhVIFa4YqWJeSRJ9tcXYS">here</a>
+            <a href="https://docs.google.com/document/d/e/2PACX-1vSDHW7gvG8eO6aIxaIVPrZSqYYhtRDb5W1imnbpM4QRYNPsTwEO1fU5z7SEhVIFa4YqWJeSRJ9tcXYS/pub">here</a>
             for agendas of past meetings.
         </p>
         <ul>


### PR DESCRIPTION
The current link was broken. I replaced it with the published doc.