### PR TITLE
Rephrase external column data.

### DIFF
--- a/data/implementations/features/api-features.yaml
+++ b/data/implementations/features/api-features.yaml
@@ -1,8 +1,8 @@
 category_id: api-features
 features:
-  - id: api-external-column-data
-    display_name: External column data
-    note: "In parquet.thrift: ColumnChunk->file_path"
+  - id: api-parquet-summary-file
+    display_name: Parquet summary file
+    note: "Files named _metadata that consolidate footers from multiple parquet files."
 
   - id: api-sorting-columns
     display_name: Row group "Sorting column" metadata

--- a/data/implementations/support/arrow-go.yaml
+++ b/data/implementations/support/arrow-go.yaml
@@ -125,7 +125,7 @@ support:
     status: read
   format-data-page-v2:
     status: full
-  api-external-column-data:
+  api-parquet-summary-file:
     status: none
   api-sorting-columns:
     status: full

--- a/data/implementations/support/arrow-rs.yaml
+++ b/data/implementations/support/arrow-rs.yaml
@@ -132,7 +132,7 @@ support:
     status: full
   format-data-page-v2:
     status: full
-  api-external-column-data:
+  api-parquet-summary-file:
     status: none
   api-sorting-columns:
     status: full

--- a/data/implementations/support/arrow.yaml
+++ b/data/implementations/support/arrow.yaml
@@ -133,7 +133,7 @@ support:
     since_version_write: "19.0.0"
   format-data-page-v2:
     status: full
-  api-external-column-data:
+  api-parquet-summary-file:
     status: full
   api-sorting-columns:
     status: full

--- a/data/implementations/support/cudf.yaml
+++ b/data/implementations/support/cudf.yaml
@@ -114,7 +114,7 @@ support:
     status: full
   format-data-page-v2:
     status: full
-  api-external-column-data:
+  api-parquet-summary-file:
     status: write
   api-sorting-columns:
     status: write

--- a/data/implementations/support/duckdb.yaml
+++ b/data/implementations/support/duckdb.yaml
@@ -126,7 +126,7 @@ support:
     status: read
   format-data-page-v2:
     status: full
-  api-external-column-data:
+  api-parquet-summary-file:
     status: none
   api-sorting-columns:
     status: read

--- a/data/implementations/support/hyparquet.yaml
+++ b/data/implementations/support/hyparquet.yaml
@@ -113,8 +113,8 @@ support:
     status: unknown
   format-data-page-v2:
     status: full
-  api-external-column-data:
-    status: full
+  api-parquet-summary-file:
+    status: none
   api-sorting-columns:
     status: none
   api-rowgroup-pruning-stats:

--- a/data/implementations/support/parquet-java.yaml
+++ b/data/implementations/support/parquet-java.yaml
@@ -123,7 +123,7 @@ support:
     status: full
   format-data-page-v2:
     status: full
-  api-external-column-data:
+  api-parquet-summary-file:
     status: full
   api-sorting-columns:
     status: none


### PR DESCRIPTION
Based on support matrix I believe this was meant to capture Parquet summary files ("_metadata") and not reading external data.

Related format PR: https://github.com/apache/parquet-format/pull/542