### PR TITLE
Add Polars to Parquet implementations

### DIFF
--- a/content/en/docs/File Format/implementationstatus.md
+++ b/content/en/docs/File Format/implementationstatus.md
@@ -26,6 +26,7 @@ The value in each box means:
 * [cudf](https://github.com/rapidsai/cudf) (cuDF C++)
 * [hyparquet](https://github.com/hyparam/hyparquet) (JavaScript)
 * [duckdb](https://github.com/duckdb/duckdb) (C++)
+* [polars](https://github.com/pola-rs/polars) (Rust)
 
 <!-- Status source in data/implementations -->
 {{< implementation-status >}}

--- a/data/implementations/engines.yaml
+++ b/data/implementations/engines.yaml
@@ -160,3 +160,16 @@
       "1.4.0":
         release_date: "2025-09-16"
         release_notes_url: "https://github.com/duckdb/duckdb/releases/tag/v1.4.0"
+
+- id: polars
+  name: polars
+  display_name: Polars
+  language: Rust
+  repo_url: https://github.com/pola-rs/polars
+  docs_url: null
+  versions:
+    default: "1.37.0"
+    releases:
+      "1.37.0":
+        release_date: "2026-01-10"
+        release_notes_url: "https://github.com/pola-rs/polars/releases/tag/py-1.37.0"

--- a/data/implementations/support/polars.yaml
+++ b/data/implementations/support/polars.yaml
@@ -1,0 +1,127 @@
+engine_id: polars
+last_updated: "2026-01-30"
+support:
+  physical-boolean:
+    status: full
+  physical-int32:
+    status: full
+  physical-int64:
+    status: full
+  physical-int96:
+    status: read
+  physical-float:
+    status: full
+  physical-double:
+    status: full
+  physical-byte-array:
+    status: full
+  physical-fixed-len-byte-array:
+    status: read
+  logical-string:
+    status: full
+  logical-enum:
+    status: read
+  logical-uuid:
+    status: read
+  logical-int-types:
+    status: full
+  logical-decimal-int32:
+    status: read
+  logical-decimal-int64:
+    status: read
+  logical-decimal-byte-array:
+    status: read
+  logical-decimal-fixed-len-byte-array:
+    status: full
+  logical-float16:
+    status: full
+  logical-date:
+    status: full
+  logical-time-int32:
+    status: read
+  logical-time-int64:
+    status: full
+  logical-timestamp-int64:
+    status: full
+  logical-interval:
+    status: read
+  logical-json:
+    status: none
+  logical-bson:
+    status: none
+  logical-variant:
+    status: none
+  logical-geometry:
+    status: read
+  logical-geography:
+    status: read
+  logical-list:
+    status: full
+  logical-map:
+    status: read
+  logical-unknown:
+    status: full
+  encoding-plain:
+    status: full
+  encoding-plain-dictionary:
+    status: read
+  encoding-rle-dictionary:
+    status: full
+  encoding-rle:
+    status: read
+  encoding-bit-packed:
+    status: none
+  encoding-delta-binary-packed:
+    status: read
+  encoding-delta-length-byte-array:
+    status: read
+  encoding-delta-byte-array:
+    status: read
+  encoding-byte-stream-split:
+    status: read
+  encoding-byte-stream-split-extended:
+    status: none
+  compression-uncompressed:
+    status: full
+  compression-brotli:
+    status: full
+  compression-gzip:
+    status: full
+  compression-lz4-deprecated:
+    status: none
+  compression-lz4-raw:
+    status: full
+  compression-lzo:
+    status: read
+  compression-snappy:
+    status: full
+  compression-zstd:
+    status: full
+  format-bloom-filters:
+    status: none
+  format-bloom-filter-length:
+    status: none
+  format-stats-min-max:
+    status: full
+  format-page-index:
+    status: read
+  format-page-crc32:
+    status: read
+  format-modular-encryption:
+    status: none
+  format-size-statistics:
+    status: read
+  format-data-page-v2:
+    status: read
+  api-parquet-summary-file:
+    status: none
+  api-sorting-columns:
+    status: read
+  api-rowgroup-pruning-stats:
+    status: full
+  api-rowgroup-pruning-bloom:
+    status: none
+  api-column-projection:
+    status: full
+  api-page-pruning-stats:
+    status: none


### PR DESCRIPTION
Similar to #104, we are heeding the [call](https://github.com/pola-rs/polars/issues/26277) to add the implementation status here. Polars has its own implementation that was forked `arrow-rs` many, many years ago, and they have grown apart a lot ever since.

Although I am no longer working at Polars, I was asked by @orlp to come out of retirement (/s) and see if I can fill this in. As I was the person mostly working on Parquet at Polars for the last 1.5 years, I have a decent idea of the status.

If this needs updating, probably @azimafroozeh, @nameexhaustion and @kdn36 are the people to tag.

Referencing:
- pola-rs/polars#22278 to control encoding, compression, page indices
- pola-rs/polars#25185 for the Float16 work
- pola-rs/polars#24320 about the interval types