### PR TITLE
Rename "Releases" to "Blog", do not change url

### DIFF
--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Releases"
-linkTitle: "Releases"
+title: "Blog"
+linkTitle: "Blog"
 menu:
   main:
     weight: 3


### PR DESCRIPTION
- Part of https://github.com/apache/parquet-site/issues/146

As we prepare to add content other than Parquet Java release announcements, I propose we also rename the part of the 

Note that this does not change the existing URL, which is https://parquet.apache.org/blog/

It only changes the text on the home page / nav bar and the page itself as shown in these screen shots

<img width="907" height="1041" alt="Screenshot 2026-02-04 at 3 12 33 PM" src="https://github.com/user-attachments/assets/3476a316-d21b-4920-8d34-dc66d186e318" />

<img width="902" height="621" alt="Screenshot 2026-02-04 at 3 12 56 PM" src="https://github.com/user-attachments/assets/c2b4962b-1d2f-4902-86f1-aed0c6f23d8d" />
