### PR TITLE
Minor: Update parquet-format pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@ This website is built / powered by [Hugo](https://gohugo.io/) with the [Docsy Th
 The following steps assume that you have `hugo` installed and working.
 You can also use docker, see the [Docker section](#docker) for more information.
 
+## Updating `/docs/file-format` documentation`
+
+The `/docs/file-format` pages (for example, https://parquet.apache.org/docs/file-format/data-pages/encodings/) are automatically 
+generated from the `parquet-format` repository. 
+To update the website to reflect the latest documentation, you need to update the 
+submodule in this repository. 
+
+
+```shell
+cd assets/parquet-format
+git checkout master
+git pull # update to the latest version of parquet-format
+cd ../..
+git add assets/parquet-format
+git commit -m "Update parquet-format submodule"
+git push
+```
+
+
 ## Building and Running Locally
 
 Clone this repository to run the website locally:


### PR DESCRIPTION
@nkaki added a very nice table to the encodings oage
- https://github.com/apache/parquet-format/pull/552

However, it does not show up on the parquet site https://parquet.apache.org/docs/file-format/data-pages/encodings/ yet

Here is how it currently looks

<img width="1156" height="683" alt="Screenshot 2026-02-09 at 10 02 58 AM" src="https://github.com/user-attachments/assets/7790cc2b-8c37-4bcc-8a8b-5312f0f0a770" />


Here is an example of how it looks locally after this PR

<img width="1198" height="1042" alt="Screenshot 2026-02-09 at 10 02 18 AM" src="https://github.com/user-attachments/assets/e7582a8c-9030-4d08-b415-9309798cd3b3" />

