### PR TITLE
Remove hugo mod get from CI to fix white navbar

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,9 +60,6 @@ jobs:
 
       - run: npm install
 
-      - name: Download Hugo modules
-        run: hugo mod get
-
       - name: Build
         run: hugo --minify --panicOnWarning
 


### PR DESCRIPTION
The navbar on parquet.apache.org has a white background instead of blue.

My speculation is that this happens because hugo mod get in CI upgrades Docsy from v0.12.0 to v0.14.2, which replaces `background: $primary` with a CSS variable that resolves to the body background (white). Since _vendor/ is gitignored, CI doesn't have the vendored Docsy and uses whatever hugo mod get pulls.

Hugo already downloads the pinned versions from go.sum during the build, so hugo mod get isn't needed and was only causing this unwanted upgrade.

Reproed locally:

Broken:
<img width="1728" height="1037" alt="Screenshot 2026-02-12 at 22 38 47" src="https://github.com/user-attachments/assets/8a2812b1-af11-454f-9d4f-fc7e53556860" />

Fixed:
<img width="1728" height="1040" alt="Screenshot 2026-02-12 at 22 39 41" src="https://github.com/user-attachments/assets/3b333347-8700-4f5a-9d94-a48b97288fcb" />


cc @alamb 