### PR TITLE
Remove 2024 BYTE_STREAM_SPLIT support from DuckDB status

### DIFF
--- a/data/implementations/support/duckdb.yaml
+++ b/data/implementations/support/duckdb.yaml
@@ -90,9 +90,7 @@ support:
   encoding-byte-stream-split:
     status: full
   encoding-byte-stream-split-extended:
-    status: full
-    since_version_read: "1.2.0"
-    since_version_write: "1.2.0"
+    status: none
   compression-uncompressed:
     status: full
   compression-brotli:


### PR DESCRIPTION
Closes #184.

DuckDB does not support BYTE_STREAM_SPLIT for physical types other than FLOAT and DOUBLE. This PR changes the implementation status to `none`.