### PR TITLE
Explicitly use an arithmetic right shift in IEEE754 total order

### DIFF
--- a/content/en/blog/features/ieee754-order.md
+++ b/content/en/blog/features/ieee754-order.md
@@ -61,6 +61,7 @@ Interestingly, implementing this ordering doesn't require a heavy, complex compa
 pub fn totalOrder(x: f64, y: f64) -> bool {
     let mut x_int = x.to_bits() as i64;
     let mut y_int = y.to_bits() as i64;
+    // arithmetic shift
     x_int ^= (((x_int >> 63) as u64) >> 1) as i64;
     y_int ^= (((y_int >> 63) as u64) >> 1) as i64;
     return x_int <= y_int;


### PR DESCRIPTION
For signed integers, the `>>` operator does not necessarily represent an arithmetic right shift in some languages ​​(for example, in C++17, it is implementation-defined). A comment is included to serve as a reminder.