### PR TITLE
Add parquet-format 2.14.0 features to the support features page

### DIFF
--- a/data/implementations/features/encodings.yaml
+++ b/data/implementations/features/encodings.yaml
@@ -48,6 +48,14 @@ features:
     feature_url: https://github.com/apache/parquet-format/blob/master/Encodings.md#byte-stream-split-byte_stream_split--9
     prs: "[#144](https://github.com/apache/parquet-format/pull/144)"
     approval: "[2019-12-03](https://lists.apache.org/thread/xs5qt2odm299pxgqb22mty2csc1so5yr)"
+  - id: encoding-alp
+    display_name: ALP
+    compatibility: forward_incompatible
+    released_in: "2.14.0"
+    feature_url: https://github.com/apache/parquet-format/blob/master/AlpEncoding.md
+    prs: "[#557](https://github.com/apache/parquet-format/pull/557), [#604](https://github.com/apache/parquet-format/pull/604), [#608](https://github.com/apache/parquet-format/pull/608)"
+    approval: "[2026-07-23](https://lists.apache.org/thread/ld025dzycrhm6dgh8p6157to7d9x8pon)"
+    version_note: "In [Preview](https://github.com/apache/parquet-format/blob/master/Encodings.md#adaptive-lossless-floating-point-alp--10): the specification is stable but ecosystem implementations are ongoing"
   - id: encoding-byte-stream-split-extended
     display_name: BYTE_STREAM_SPLIT (Additional Types)
     spec_url: https://github.com/apache/parquet-format/commit/e517ac4dbe08d518eb5c2e58576d4c711973db94

--- a/data/implementations/features/encodings.yaml
+++ b/data/implementations/features/encodings.yaml
@@ -52,6 +52,8 @@ features:
     display_name: ALP
     compatibility: forward_incompatible
     released_in: "2.14.0"
+    # TODO: placeholder date; update when the parquet-format 2.14.0 release vote is finalized
+    release_date: '2026-09-09'
     feature_url: https://github.com/apache/parquet-format/blob/master/AlpEncoding.md
     prs: "[#557](https://github.com/apache/parquet-format/pull/557), [#604](https://github.com/apache/parquet-format/pull/604), [#608](https://github.com/apache/parquet-format/pull/608)"
     approval: "[2026-07-23](https://lists.apache.org/thread/ld025dzycrhm6dgh8p6157to7d9x8pon)"

--- a/data/implementations/features/format-features.yaml
+++ b/data/implementations/features/format-features.yaml
@@ -85,3 +85,12 @@ features:
     feature_url: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L1061
     prs: "[#514](https://github.com/apache/parquet-format/pull/514)"
     approval: "[2026-05-26](https://lists.apache.org/thread/h0k0hqo0sojqphnbnrkp8b0gmwdzq9on)"
+  - id: format-int96-timestamp-order
+    display_name: INT96 chronological timestamp order
+    note: 'In parquet.thrift: ColumnOrder->INT96_TIMESTAMP_ORDER'
+    implementation_status: false
+    compatibility: forward_compatible
+    released_in: "2.14.0"
+    feature_url: https://github.com/apache/parquet-format/blob/04d56f291ff963e98bc37ab8100e2fc133ff583c/src/main/thrift/parquet.thrift#L1085
+    prs: "[#584](https://github.com/apache/parquet-format/pull/584)"
+    approval: "[2026-07-06](https://lists.apache.org/thread/4kq2gfgx3cmow26h8ofd93653z9zhs2t)"

--- a/data/implementations/features/logical-types.yaml
+++ b/data/implementations/features/logical-types.yaml
@@ -130,6 +130,14 @@ features:
     feature_url: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#geography
     prs: "[#240](https://github.com/apache/parquet-format/pull/240)"
     approval: "[2025-02-09](https://lists.apache.org/thread/s6s714c98cn9gg22mnk5nsn7xymym8xo)"
+  - id: logical-file
+    display_name: FILE
+    version_display_name: FILE (group)
+    compatibility: forward_compatible
+    released_in: "2.14.0"
+    feature_url: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#file
+    prs: "[#585](https://github.com/apache/parquet-format/pull/585), [#603](https://github.com/apache/parquet-format/pull/603)"
+    approval: "[2026-07-18](https://lists.apache.org/thread/lbtdvq63382fgl2049zb6vn396h9lmfz)"
   - id: logical-list
     display_name: LIST
     compatibility: forward_compatible

--- a/data/implementations/features/logical-types.yaml
+++ b/data/implementations/features/logical-types.yaml
@@ -135,6 +135,8 @@ features:
     version_display_name: FILE (group)
     compatibility: forward_compatible
     released_in: "2.14.0"
+    # TODO: placeholder date; update when the parquet-format 2.14.0 release vote is finalized
+    release_date: '2026-09-09'
     feature_url: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#file
     prs: "[#585](https://github.com/apache/parquet-format/pull/585), [#603](https://github.com/apache/parquet-format/pull/603)"
     approval: "[2026-07-18](https://lists.apache.org/thread/lbtdvq63382fgl2049zb6vn396h9lmfz)"

--- a/data/implementations/parquet-format-releases.yaml
+++ b/data/implementations/parquet-format-releases.yaml
@@ -54,3 +54,8 @@
   tag: apache-parquet-format-2.13.0
   source_url: https://github.com/apache/parquet-format/compare/apache-parquet-format-2.12.0...apache-parquet-format-2.13.0
   source_display: 2.12.0..2.13.0
+# Note: 2.14.0 has not yet been released; these links will resolve once it is.
+"2.14.0":
+  tag: apache-parquet-format-2.14.0
+  source_url: https://github.com/apache/parquet-format/compare/apache-parquet-format-2.13.0...apache-parquet-format-2.14.0
+  source_display: 2.13.0..2.14.0

--- a/data/implementations/support/arrow-go.yaml
+++ b/data/implementations/support/arrow-go.yaml
@@ -59,6 +59,8 @@ support:
     status: none
   logical-geography:
     status: none
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/arrow-go.yaml
+++ b/data/implementations/support/arrow-go.yaml
@@ -85,6 +85,8 @@ support:
     status: full
     since_version_read: "18.0.0"
     since_version_write: "18.0.0"
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: full
     since_version_read: "18.0.0"

--- a/data/implementations/support/arrow-rs.yaml
+++ b/data/implementations/support/arrow-rs.yaml
@@ -94,6 +94,8 @@ support:
     status: full
     since_version_read: "52.2.0"
     since_version_write: "52.2.0"
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: full
     since_version_read: "53.0.0"

--- a/data/implementations/support/arrow-rs.yaml
+++ b/data/implementations/support/arrow-rs.yaml
@@ -67,6 +67,8 @@ support:
     status: full
     since_version_read: "57.0.0"
     since_version_write: "57.0.0"
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/arrow.yaml
+++ b/data/implementations/support/arrow.yaml
@@ -89,6 +89,8 @@ support:
     status: full
     since_version_read: "16.0.0"
     since_version_write: "16.0.0"
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: full
     since_version_read: "16.0.0"

--- a/data/implementations/support/arrow.yaml
+++ b/data/implementations/support/arrow.yaml
@@ -63,6 +63,8 @@ support:
     status: full
     since_version_read: "21.0.0"
     since_version_write: "21.0.0"
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/cudf.yaml
+++ b/data/implementations/support/cudf.yaml
@@ -79,6 +79,8 @@ support:
     status: full
   encoding-byte-stream-split:
     status: full
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: unknown
   compression-uncompressed:

--- a/data/implementations/support/cudf.yaml
+++ b/data/implementations/support/cudf.yaml
@@ -55,6 +55,8 @@ support:
     status: none
   logical-geography:
     status: none
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/duckdb.yaml
+++ b/data/implementations/support/duckdb.yaml
@@ -89,6 +89,8 @@ support:
     status: full
   encoding-byte-stream-split:
     status: full
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: none
   compression-uncompressed:

--- a/data/implementations/support/duckdb.yaml
+++ b/data/implementations/support/duckdb.yaml
@@ -63,6 +63,8 @@ support:
     status: full
     since_version_read: "1.4.0"
     since_version_write: "1.4.0"
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/hyparquet.yaml
+++ b/data/implementations/support/hyparquet.yaml
@@ -58,6 +58,8 @@ support:
   logical-geography:
     status: full
     since_version_read: "1.19.0"
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/hyparquet.yaml
+++ b/data/implementations/support/hyparquet.yaml
@@ -82,6 +82,8 @@ support:
     status: full
   encoding-byte-stream-split:
     status: full
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: full
   compression-uncompressed:

--- a/data/implementations/support/parquet-java.yaml
+++ b/data/implementations/support/parquet-java.yaml
@@ -65,6 +65,8 @@ support:
     status: full
     since_version_read: "1.16.0"
     since_version_write: "1.16.0"
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/parquet-java.yaml
+++ b/data/implementations/support/parquet-java.yaml
@@ -89,6 +89,8 @@ support:
     status: full
   encoding-byte-stream-split:
     status: full
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: full
   compression-uncompressed:

--- a/data/implementations/support/polars.yaml
+++ b/data/implementations/support/polars.yaml
@@ -55,6 +55,8 @@ support:
     status: read
   logical-geography:
     status: read
+  logical-file:
+    status: none
   logical-list:
     status: full
   logical-map:

--- a/data/implementations/support/polars.yaml
+++ b/data/implementations/support/polars.yaml
@@ -79,6 +79,8 @@ support:
     status: read
   encoding-byte-stream-split:
     status: read
+  encoding-alp:
+    status: none
   encoding-byte-stream-split-extended:
     status: none
   compression-uncompressed:

--- a/layouts/shortcodes/implementation-status.html
+++ b/layouts/shortcodes/implementation-status.html
@@ -269,7 +269,8 @@
 
 {{- /* Collect all features with release_date and group by year */ -}}
 {{- $featuresByYear := dict "2023" (slice) "2024" (slice) "2025" (slice) -}}
-{{- $excludedFeatures := slice "encoding-bit-packed" "compression-lz4-deprecated" "compression-lzo" "logical-enum" "logical-uuid" "logical-bson" "logical-json" "logical-interval" -}}
+{{- /* encoding-alp and logical-file are excluded because parquet-format 2.14.0 is not yet released. */ -}}
+{{- $excludedFeatures := slice "encoding-bit-packed" "compression-lz4-deprecated" "compression-lzo" "logical-enum" "logical-uuid" "logical-bson" "logical-json" "logical-interval" "encoding-alp" "logical-file" -}}
 {{- $includedCategories := slice "compressions" "encodings" "physical-types" "logical-types" -}}
 
 {{- range $categories -}}

--- a/layouts/shortcodes/implementation-status.html
+++ b/layouts/shortcodes/implementation-status.html
@@ -268,9 +268,8 @@
 <p><b>Note:</b> This data was originally collected in December 2025, and not all data was backfilled. It is likely older releases of each engine support reading all features for 2023 and before. As volunteers have time they are invited to add more granular details on releases. Generally, versions are expected to be accurate for any year 2025 and after.</p>
 
 {{- /* Collect all features with release_date and group by year */ -}}
-{{- $featuresByYear := dict "2023" (slice) "2024" (slice) "2025" (slice) -}}
-{{- /* encoding-alp and logical-file are excluded because parquet-format 2.14.0 is not yet released. */ -}}
-{{- $excludedFeatures := slice "encoding-bit-packed" "compression-lz4-deprecated" "compression-lzo" "logical-enum" "logical-uuid" "logical-bson" "logical-json" "logical-interval" "encoding-alp" "logical-file" -}}
+{{- $featuresByYear := dict "2023" (slice) "2024" (slice) "2025" (slice) "2026" (slice) -}}
+{{- $excludedFeatures := slice "encoding-bit-packed" "compression-lz4-deprecated" "compression-lzo" "logical-enum" "logical-uuid" "logical-bson" "logical-json" "logical-interval" -}}
 {{- $includedCategories := slice "compressions" "encodings" "physical-types" "logical-types" -}}
 
 {{- range $categories -}}
@@ -288,7 +287,9 @@
           {{- $year := "" -}}
           {{- if .release_date -}}
             {{- $dateStr := .release_date -}}
-            {{- if hasPrefix $dateStr "2025" -}}
+            {{- if hasPrefix $dateStr "2026" -}}
+              {{- $year = "2026" -}}
+            {{- else if hasPrefix $dateStr "2025" -}}
               {{- $year = "2025" -}}
             {{- else if hasPrefix $dateStr "2024" -}}
               {{- $year = "2024" -}}
@@ -340,6 +341,7 @@
       <th>≤2023 Features</th>
       <th>2024 Features</th>
       <th>2025 Features</th>
+      <th>2026 Features</th>
     </tr>
   </thead>
   <tbody>
@@ -357,7 +359,7 @@
         {{- $cumulativeMissingFeatures := slice -}}
         {{- $hasPriorMissingFeatures := false -}}
 
-        {{- range $year := slice "2023" "2024" "2025" -}}
+        {{- range $year := slice "2023" "2024" "2025" "2026" -}}
           {{- $features := index $featuresByYear $year -}}
           {{- $minVersion := $cumulativeMinVersion -}}
           {{- $minReleaseDate := $cumulativeMinReleaseDate -}}


### PR DESCRIPTION
~**Note:** This PR will stay in draft and must not be merged until the [2.14.0 RC1 release vote](https://lists.apache.org/thread/ovo7vhh2gp31v32xzq6wm5f0grk97bs3) passes.~

## Rationale

Keep the page up to date

parquet-format 2.14.0 has been released: [[VOTE] Release Apache Parquet Format 2.14.0 RC1](https://lists.apache.org/thread/ovo7vhh2gp31v32xzq6wm5f0grk97bs3).

## Preview

Rendered preview
* https://alamb.github.io/parquet-site/docs/file-format/versions/
* https://alamb.github.io/parquet-site/docs/file-format/implementationstatus/

<img width="1255" height="1187" alt="Screenshot 2026-09-16 at 5 03 59 PM" src="https://github.com/user-attachments/assets/726c9bdb-da95-47b6-9ede-356f5c57657b" />
<img width="1061" height="1105" alt="Screenshot 2026-09-16 at 5 04 16 PM" src="https://github.com/user-attachments/assets/d83f1faf-98e8-489b-ade2-6a9a12b6cfd6" />
<img width="1071" height="992" alt="Screenshot 2026-09-16 at 5 04 49 PM" src="https://github.com/user-attachments/assets/eaf689cf-050b-470f-a1c2-c30e01bbe3bc" />
<img width="960" height="575" alt="Screenshot 2026-09-16 at 5 05 20 PM" src="https://github.com/user-attachments/assets/fc4f5d20-fd52-4a02-a97e-5f166496b627" />
<img width="1225" height="687" alt="Screenshot 2026-09-16 at 5 07 59 PM" src="https://github.com/user-attachments/assets/a767c34a-ae14-49f8-b27d-23f5112b2335" />


## Details 
This PR adds all the format features included in that release to the [Features and Versions](https://parquet.apache.org/docs/file-format/versions/) page and the [Implementation Status](https://parquet.apache.org/docs/file-format/implementationstatus/) matrix:
* ALP Encoding
* Logical Type

Replaces #199, which covered only ALP.

Also adds features for the newly release arrow-rs Rust version 60.0.0



